### PR TITLE
Add renovate.json to automate dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json?raw=true"
+  ],
+  "assigneesFromCodeOwners": true,
+  "automergeStrategy": "auto",
+  "automergeType": "pr",
+  "prConcurrentLimit": 5,
+  "ignoreTests": false,
+  "rebaseLabel": "needs-rebase",
+  "rebaseWhen": "behind-base-branch",
+  "recreateWhen": "always",
+  "commitMessageSuffix": "{{baseBranch}}",
+  "tekton": {
+    "enabled": true,
+    "packageRules": [
+      {
+        "matchUpdateTypes": [
+          "minor",
+          "patch",
+          "pin",
+          "digest"
+        ],
+        "automerge": true,
+        "addLabels": ["lgtm", "approved"]
+      }
+    ]
+  },
+  "dockerfile": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
- Introduce a renovate.json configuration based on the kueue-operator example.
- Enable auto-merging for konflux image updates.
- Explicitly disable updates for all Containerfile.catalog files to avoid unwanted PRs for container definitions.
- This setup will help keep dependencies up-to-date while reducing noise from unnecessary updates.