### PR TITLE
use 4.19 context for 4.19 rather than 4.18

### DIFF
--- a/.tekton/kueue-fbc-4-19-push.yaml
+++ b/.tekton/kueue-fbc-4-19-push.yaml
@@ -29,7 +29,7 @@ spec:
   - name: dockerfile
     value: v4.19/Containerfile.catalog
   - name: path-context
-    value: v4.18
+    value: v4.19
   pipelineSpec:
     description: |
       This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/end-to-end/building-olm/#building-the-file-based-catalog).


### PR DESCRIPTION
We should be using the v4.19 directory for the fbc-4-19 push.