### PR TITLE
add get-snapshots script and claude command

### DIFF
--- a/.claude/commands/get-snapshots.md
+++ b/.claude/commands/get-snapshots.md
@@ -1,0 +1,13 @@
+Run the get-snapshots script to fetch the latest Konflux snapshots:
+
+```bash
+./get-snapshots.py $ARGUMENTS
+```
+
+Prerequisites:
+- `kubectl` must be installed and available in PATH
+- Your kubeconfig must be configured with access to the `stone-prd-rh01` cluster and you must be in the `kueue-operator-tenant` namespace/project
+- If you don't have access to the cluster, ask a maintainer for instructions on how to get set up
+- If the script fails with authentication or resource errors, verify you are logged into the correct cluster and namespace
+
+Display the output to the user.

--- a/get-snapshots.py
+++ b/get-snapshots.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Get the latest Konflux snapshots for kueue-fbc components.
+
+Usage: ./get-snapshots.py [4.18,4.19,4.20,4.21]
+  If no argument is provided, auto-detects versions from .tekton/kueue-fbc-*-push.yaml files.
+"""
+
+import glob
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+KUBECTL = shutil.which("kubectl")
+KUBECTL_TIMEOUT_SECONDS = 30
+
+
+def discover_components():
+    """Discover components from .tekton pipeline files."""
+    components = []
+    pattern = os.path.join(SCRIPT_DIR, ".tekton", "kueue-fbc-*-push.yaml")
+    for path in sorted(glob.glob(pattern)):
+        name = os.path.basename(path).removesuffix("-push.yaml")
+        version = name.removeprefix("kueue-fbc-").replace("-", ".")
+        components.append((version, name))
+    return components
+
+
+def get_latest_snapshot(component):
+    """Query kubectl for the latest snapshot of a component."""
+    if not KUBECTL:
+        print("kubectl not found in PATH. Install kubectl to use this script.", file=sys.stderr)
+        return None
+    try:
+        result = subprocess.run(
+            [
+                KUBECTL, "get", "snapshots",
+                "-l", f"appstudio.openshift.io/component={component}",
+                "--sort-by=.metadata.creationTimestamp",
+                "-o", "json",
+            ],
+            capture_output=True, text=True, check=True,
+            timeout=KUBECTL_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        print(f"Timeout querying snapshots for {component}", file=sys.stderr)
+        return None
+    except subprocess.CalledProcessError as e:
+        print(f"Error querying snapshots for {component}: {e.stderr}", file=sys.stderr)
+        print(
+            "Ensure your kubeconfig is set to a cluster with Konflux Snapshot CRDs installed.",
+            file=sys.stderr,
+        )
+        return None
+
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        print(f"Invalid JSON from kubectl for {component}", file=sys.stderr)
+        return None
+    items = data.get("items", [])
+    if not items:
+        return None
+
+    latest = items[-1]
+    metadata = latest.get("metadata", {})
+    name = metadata.get("name")
+    created_ts = metadata.get("creationTimestamp")
+    if not name or not created_ts:
+        return None
+    created = created_ts.split("T")[0]
+    images = [c["containerImage"] for c in latest.get("spec", {}).get("components", [])]
+    image = images[0] if images else "-"
+    return name, created, image
+
+
+def main():
+    all_components = discover_components()
+
+    if len(sys.argv) > 1:
+        requested = {v.strip() for v in sys.argv[1].split(",")}
+        components = [(v, n) for v, n in all_components if v in requested]
+    else:
+        components = all_components
+
+    if not components:
+        print("No matching components found.", file=sys.stderr)
+        sys.exit(1)
+
+    # Print table
+    print(f"| {'OCP':<8} | {'Snapshot':<45} | {'Created':<12} | Container Image")
+    print(f"|{'-'*10}|{'-'*47}|{'-'*14}|---")
+
+    anomalies = []
+    for version, component in components:
+        snapshot = get_latest_snapshot(component)
+        if snapshot is None:
+            print(f"| {version:<8} | {'(none found)':<45} | {'-':<12} | -")
+            continue
+
+        name, created, image = snapshot
+        print(f"| {version:<8} | {name:<45} | {created:<12} | {image}")
+
+        if component not in image:
+            anomalies.append(
+                f"{version}: image path does not contain expected component name '{component}'"
+            )
+
+    if anomalies:
+        print("\nAnomalies:")
+        for a in anomalies:
+            print(f"  - {a}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `get-snapshots.py` — a Python script to query Konflux for the latest FBC snapshots across OCP versions, with anomaly detection
- Adds `/get-snapshots` Claude Code command to invoke the script
- Auto-discovers components from `.tekton/kueue-fbc-*-push.yaml` files
- Supports filtering by version (e.g. `./get-snapshots.py 4.18,4.19`)

## Example output

```
| OCP      | Snapshot                                      | Created      | Container Image
|----------|-----------------------------------------------|--------------|---
| 4.18     | kueue-fbc-4-18-20260406-174549-000            | 2026-04-06   | quay.io/redhat-user-workloads/kueue-operator-tenant/kueue-fbc-4-18@sha256:578571c636696422c8bf66a34043a573164133dad7e80bf0c19aae3a3ae1b351
| 4.19     | kueue-fbc-4-19-20260406-174550-000            | 2026-04-06   | quay.io/redhat-user-workloads/kueue-operator-tenant/kueue-fbc-4-19@sha256:544b22869d81e4e964786d5fa8fb09f1a7d7919407d79be396a024f430baee38
| 4.20     | kueue-fbc-4-20-20260404-055301-000            | 2026-04-04   | quay.io/redhat-user-workloads/kueue-operator-tenant/kueue-fbc-4-20@sha256:8d3340c28354d1dc8892443e556fde6ce966e535918ff28cf82f70b2d0c0fd7b
| 4.21     | kueue-fbc-4-21-20260404-055303-000            | 2026-04-04   | quay.io/redhat-user-workloads/kueue-operator-tenant/lws-fbc-4-21/lws-fbc-4-21@sha256:a59e5af2870f3b31d37ea81a2b11259c1049ea451cf98b983d036af4aea6a181

Anomalies:
  - 4.21: image path does not contain expected component name 'kueue-fbc-4-21'
```

## Test plan

- [ ] Run `./get-snapshots.py` with no args to verify auto-detection
- [ ] Run `./get-snapshots.py 4.18,4.19` to verify filtering
- [ ] Run `/get-snapshots` in Claude Code to verify the command works

🤖 Generated with [Claude Code](https://claude.com/claude-code)