### PR TITLE
add fbc 4.22 files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,12 @@ Regenerates catalog.json files for all supported OCP versions. This script:
 - Uses OPM (Operator Package Manager) to render catalog templates
 - Uses `--migrate-level=bundle-object-to-csv-metadata` flag for all supported versions
 
+### Add New OCP Version
+```bash
+./add-ocp-version.sh <version>
+```
+Scaffolds a new OCP version directory by copying from the latest existing version. Example: `./add-ocp-version.sh 4.23` creates `v4.23/` with the catalog template, Containerfile, and catalog.json from the latest version.
+
 ### Lint Catalogs
 ```bash
 ./lint.sh

--- a/add-ocp-version.sh
+++ b/add-ocp-version.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <new-version>"
+    echo "Example: $0 4.23"
+    exit 1
+fi
+
+NEW_VERSION="$1"
+NEW_DIR="v${NEW_VERSION}"
+
+if [ -d "$NEW_DIR" ]; then
+    echo "Error: $NEW_DIR already exists"
+    exit 1
+fi
+
+# Find the latest existing version directory to copy from
+LATEST_DIR=$(ls -d v4.* | sort -t. -k2 -n | tail -1)
+
+echo "Creating $NEW_DIR from $LATEST_DIR..."
+
+mkdir -p "$NEW_DIR/catalog/kueue-operator"
+cp "$LATEST_DIR/catalog-template.yaml" "$NEW_DIR/catalog-template.yaml"
+cp "$LATEST_DIR/catalog/kueue-operator/catalog.json" "$NEW_DIR/catalog/kueue-operator/catalog.json"
+sed "s/${LATEST_DIR}/${NEW_DIR}/" "$LATEST_DIR/Containerfile.catalog" > "$NEW_DIR/Containerfile.catalog"
+
+echo "Done. Created:"
+echo "  $NEW_DIR/catalog-template.yaml"
+echo "  $NEW_DIR/Containerfile.catalog"
+echo "  $NEW_DIR/catalog/kueue-operator/catalog.json"

--- a/v4.22/Containerfile.catalog
+++ b/v4.22/Containerfile.catalog
@@ -1,0 +1,21 @@
+# The base image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
+FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.22
+
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
+
+COPY catalog/ /configs
+
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+# Core bundle labels.
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=kueue-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.33.1
+LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
+LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
+LABEL operators.operatorframework.io.index.configs.v1=/configs

--- a/v4.22/catalog-template.yaml
+++ b/v4.22/catalog-template.yaml
@@ -1,0 +1,7 @@
+Schema: olm.semver
+GenerateMajorChannels: false
+GenerateMinorChannels: true
+DefaultChannelTypePreference: "minor"
+Stable:
+  Bundles:
+  - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:c3e536c99c8ccb6777561d53a5af07bf604e9ddbf945fa430e91c0c10dd3aaf0

--- a/v4.22/catalog/kueue-operator/catalog.json
+++ b/v4.22/catalog/kueue-operator/catalog.json
@@ -1,0 +1,141 @@
+{
+    "schema": "olm.package",
+    "name": "kueue-operator",
+    "defaultChannel": "stable-v1.3"
+}
+{
+    "schema": "olm.channel",
+    "name": "stable-v1.3",
+    "package": "kueue-operator",
+    "entries": [
+        {
+            "name": "kueue-operator.v1.3.1"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "kueue-operator.v1.3.1",
+    "package": "kueue-operator",
+    "image": "registry.redhat.io/kueue/kueue-operator-bundle@sha256:c3e536c99c8ccb6777561d53a5af07bf604e9ddbf945fa430e91c0c10dd3aaf0",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "kueue.openshift.io",
+                "kind": "Kueue",
+                "version": "v1"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "kueue-operator",
+                "version": "1.3.1"
+            }
+        },
+        {
+            "type": "olm.csv.metadata",
+            "value": {
+                "annotations": {
+                    "alm-examples": "[\n  {\n    \"apiVersion\": \"kueue.openshift.io/v1\",\n    \"kind\": \"Kueue\",\n    \"metadata\": {\n      \"labels\": {\n        \"app.kubernetes.io/managed-by\": \"kustomize\",\n        \"app.kubernetes.io/name\": \"kueue-operator\"\n      },\n      \"name\": \"cluster\"\n    },\n    \"spec\": {\n      \"config\": {\n        \"integrations\": {\n          \"frameworks\": [\n            \"BatchJob\"\n          ]\n        }\n      },\n      \"managementState\": \"Managed\"\n    }\n  }\n]",
+                    "capabilities": "Basic Install",
+                    "console.openshift.io/operator-monitoring-default": "true",
+                    "createdAt": "2026-04-01T18:56:21Z",
+                    "features.operators.openshift.io/cnf": "false",
+                    "features.operators.openshift.io/cni": "false",
+                    "features.operators.openshift.io/csi": "false",
+                    "features.operators.openshift.io/disconnected": "true",
+                    "features.operators.openshift.io/fips-compliant": "true",
+                    "features.operators.openshift.io/proxy-aware": "false",
+                    "features.operators.openshift.io/tls-profiles": "false",
+                    "features.operators.openshift.io/token-auth-aws": "false",
+                    "features.operators.openshift.io/token-auth-azure": "false",
+                    "features.operators.openshift.io/token-auth-gcp": "false",
+                    "operatorframework.io/cluster-monitoring": "true",
+                    "operatorframework.io/suggested-namespace": "openshift-kueue-operator",
+                    "operators.openshift.io/valid-subscription": "[\"OpenShift Kubernetes Engine\", \"OpenShift Container Platform\", \"OpenShift Platform Plus\"]",
+                    "operators.operatorframework.io/builder": "operator-sdk-v1.37.0",
+                    "operators.operatorframework.io/project_layout": "go.kubebuilder.io/v4"
+                },
+                "apiServiceDefinitions": {},
+                "crdDescriptions": {
+                    "owned": [
+                        {
+                            "name": "kueues.kueue.openshift.io",
+                            "version": "v1",
+                            "kind": "Kueue",
+                            "displayName": "Kueue",
+                            "description": "Kueue is a cluster resource for configuration of the Kueue operand"
+                        }
+                    ]
+                },
+                "description": "Red Hat build of Kueue is a collection of APIs, based on the [Kueue](https://kueue.sigs.k8s.io/docs/) open source project, that extends Kubernetes to manage access to resources for jobs. Red Hat build of Kueue does not replace any existing components in a Kubernetes cluster, but instead integrates with the existing Kubernetes API server, scheduler, and cluster autoscaler components to determine when a job waits, is admitted to start by creating pods, or should be preempted.",
+                "displayName": "Red Hat build of Kueue",
+                "installModes": [
+                    {
+                        "type": "OwnNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "SingleNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "MultiNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "AllNamespaces",
+                        "supported": true
+                    }
+                ],
+                "keywords": [
+                    "kueue-operator"
+                ],
+                "labels": {
+                    "operatorframework.io/arch.amd64": "supported",
+                    "operatorframework.io/arch.arm64": "supported",
+                    "operatorframework.io/arch.ppc64le": "supported",
+                    "operatorframework.io/arch.s390x": "supported"
+                },
+                "links": [
+                    {
+                        "name": "Kueue Operator",
+                        "url": "https://github.com/openshift/kueue-operator"
+                    }
+                ],
+                "maintainers": [
+                    {
+                        "name": "Node team",
+                        "email": "aos-node@redhat.com"
+                    }
+                ],
+                "maturity": "stable",
+                "minKubeVersion": "1.28.0",
+                "provider": {
+                    "name": "Red Hat, Inc",
+                    "url": "https://github.com/openshift/kueue-operator"
+                }
+            }
+        }
+    ],
+    "relatedImages": [
+        {
+            "name": "must-gather",
+            "image": "registry.redhat.io/kueue/kueue-must-gather-rhel9@sha256:01bc7fe88acb8729cf08551cad62f7ba02de88f6c267189d005250ff6a0f1285"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/kueue/kueue-operator-bundle@sha256:c3e536c99c8ccb6777561d53a5af07bf604e9ddbf945fa430e91c0c10dd3aaf0"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/kueue/kueue-rhel9-operator@sha256:2a1ed0265396ca5bc324fa5c7587c9304abda9323c80687b875acb6eb7994e2b"
+        },
+        {
+            "name": "operand-image",
+            "image": "registry.redhat.io/kueue/kueue-rhel9@sha256:9ad4355bb1ae356b239f3517a56a21c0ef5979c78ea8eebc936eee5c42560acc"
+        }
+    ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OpenShift Container Platform 4.22 support with pre-configured operator catalogs, templates, and container build configurations for seamless integration
  * Introduced new CLI command to automate scaffolding and configuration of additional OCP versions with proper directory structure and metadata

* **Documentation**
  * Updated documentation with comprehensive workflow for deploying and managing new OpenShift Container Platform versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->