### PR TITLE
update to use registry.redhat

### DIFF
--- a/Containerfile.catalog.template
+++ b/Containerfile.catalog.template
@@ -1,5 +1,5 @@
 # The base image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:OCP_VERSION
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:OCP_VERSION
 
 ENTRYPOINT ["/bin/opm"]
 CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]

--- a/v4.19/Containerfile.catalog
+++ b/v4.19/Containerfile.catalog
@@ -1,5 +1,5 @@
 # The base image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.19
 
 ENTRYPOINT ["/bin/opm"]
 CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]

--- a/v4.20/Containerfile.catalog
+++ b/v4.20/Containerfile.catalog
@@ -1,5 +1,5 @@
 # The base image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.20
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.20
 
 ENTRYPOINT ["/bin/opm"]
 CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]

--- a/v4.21/Containerfile.catalog
+++ b/v4.21/Containerfile.catalog
@@ -1,5 +1,5 @@
 # The base image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.21
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.21
 
 ENTRYPOINT ["/bin/opm"]
 CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]

--- a/v4.22/Containerfile.catalog
+++ b/v4.22/Containerfile.catalog
@@ -1,5 +1,5 @@
 # The base image is expected to contain /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.22
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.22
 
 ENTRYPOINT ["/bin/opm"]
 CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the container base image source across multiple release versions to a new registry to standardize image sourcing and align with platform registry conventions. No runtime behavior, commands, or labels were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->