### PR TITLE
OCPKUEUE-678: Update bundle images for release 1.4.0

### DIFF
--- a/v4.18/catalog-template.yaml
+++ b/v4.18/catalog-template.yaml
@@ -13,3 +13,4 @@ Stable:
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:005047a1a84c92358df9736f9661136e185b1b9d4d9a2eeeb322aa6cb61d63a1
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:c26330443adc06876f5cc55952f78c7247a16bf577cc39d3e55eb3b695412361
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:c3e536c99c8ccb6777561d53a5af07bf604e9ddbf945fa430e91c0c10dd3aaf0
+  - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:eff8cc23c2f37ba4c1a27a622aa87ae0ad3190b95b5c78b064f0605249c6189a

--- a/v4.18/catalog/kueue-operator/catalog.json
+++ b/v4.18/catalog/kueue-operator/catalog.json
@@ -1,7 +1,7 @@
 {
     "schema": "olm.package",
     "name": "kueue-operator",
-    "defaultChannel": "stable-v1.3"
+    "defaultChannel": "stable-v1.4"
 }
 {
     "schema": "olm.channel",
@@ -78,6 +78,17 @@
             "skips": [
                 "kueue-operator.v1.3.0"
             ]
+        }
+    ]
+}
+
+{
+    "schema": "olm.channel",
+    "name": "stable-v1.4",
+    "package": "kueue-operator",
+    "entries": [
+        {
+            "name": "kueue-operator.v1.4.0"
         }
     ]
 }
@@ -1162,6 +1173,132 @@
         {
             "name": "operand-image",
             "image": "registry.redhat.io/kueue/kueue-rhel9@sha256:9ad4355bb1ae356b239f3517a56a21c0ef5979c78ea8eebc936eee5c42560acc"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "kueue-operator.v1.4.0",
+    "package": "kueue-operator",
+    "image": "registry.redhat.io/kueue/kueue-operator-bundle@sha256:eff8cc23c2f37ba4c1a27a622aa87ae0ad3190b95b5c78b064f0605249c6189a",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "kueue.openshift.io",
+                "kind": "Kueue",
+                "version": "v1"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "kueue-operator",
+                "version": "1.4.0"
+            }
+        },
+        {
+            "type": "olm.csv.metadata",
+            "value": {
+                "annotations": {
+                    "alm-examples": "[\n  {\n    \"apiVersion\": \"kueue.openshift.io/v1\",\n    \"kind\": \"Kueue\",\n    \"metadata\": {\n      \"labels\": {\n        \"app.kubernetes.io/managed-by\": \"kustomize\",\n        \"app.kubernetes.io/name\": \"kueue-operator\"\n      },\n      \"name\": \"cluster\"\n    },\n    \"spec\": {\n      \"config\": {\n        \"integrations\": {\n          \"frameworks\": [\n            \"BatchJob\"\n          ]\n        }\n      },\n      \"managementState\": \"Managed\"\n    }\n  }\n]",
+                    "capabilities": "Basic Install",
+                    "console.openshift.io/operator-monitoring-default": "true",
+                    "createdAt": "2026-06-12T20:43:50Z",
+                    "features.operators.openshift.io/cnf": "false",
+                    "features.operators.openshift.io/cni": "false",
+                    "features.operators.openshift.io/csi": "false",
+                    "features.operators.openshift.io/disconnected": "true",
+                    "features.operators.openshift.io/fips-compliant": "true",
+                    "features.operators.openshift.io/proxy-aware": "false",
+                    "features.operators.openshift.io/tls-profiles": "true",
+                    "features.operators.openshift.io/token-auth-aws": "false",
+                    "features.operators.openshift.io/token-auth-azure": "false",
+                    "features.operators.openshift.io/token-auth-gcp": "false",
+                    "operatorframework.io/cluster-monitoring": "true",
+                    "operatorframework.io/suggested-namespace": "openshift-kueue-operator",
+                    "operators.openshift.io/valid-subscription": "[\"OpenShift Kubernetes Engine\", \"OpenShift Container Platform\", \"OpenShift Platform Plus\"]",
+                    "operators.operatorframework.io/builder": "operator-sdk-v1.37.0",
+                    "operators.operatorframework.io/project_layout": "go.kubebuilder.io/v4"
+                },
+                "apiServiceDefinitions": {},
+                "crdDescriptions": {
+                    "owned": [
+                        {
+                            "name": "kueues.kueue.openshift.io",
+                            "version": "v1",
+                            "kind": "Kueue",
+                            "displayName": "Kueue",
+                            "description": "Kueue is a cluster resource for configuration of the Kueue operand"
+                        }
+                    ]
+                },
+                "description": "Red Hat build of Kueue is a collection of APIs, based on the [Kueue](https://kueue.sigs.k8s.io/docs/) open source project, that extends Kubernetes to manage access to resources for jobs. Red Hat build of Kueue does not replace any existing components in a Kubernetes cluster, but instead integrates with the existing Kubernetes API server, scheduler, and cluster autoscaler components to determine when a job waits, is admitted to start by creating pods, or should be preempted.",
+                "displayName": "Red Hat build of Kueue",
+                "installModes": [
+                    {
+                        "type": "OwnNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "SingleNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "MultiNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "AllNamespaces",
+                        "supported": true
+                    }
+                ],
+                "keywords": [
+                    "kueue-operator"
+                ],
+                "labels": {
+                    "operatorframework.io/arch.amd64": "supported",
+                    "operatorframework.io/arch.arm64": "supported",
+                    "operatorframework.io/arch.ppc64le": "supported",
+                    "operatorframework.io/arch.s390x": "supported"
+                },
+                "links": [
+                    {
+                        "name": "Kueue Operator",
+                        "url": "https://github.com/openshift/kueue-operator"
+                    }
+                ],
+                "maintainers": [
+                    {
+                        "name": "Node team",
+                        "email": "aos-node@redhat.com"
+                    }
+                ],
+                "maturity": "stable",
+                "minKubeVersion": "1.28.0",
+                "provider": {
+                    "name": "Red Hat, Inc",
+                    "url": "https://github.com/openshift/kueue-operator"
+                }
+            }
+        }
+    ],
+    "relatedImages": [
+        {
+            "name": "must-gather",
+            "image": "registry.redhat.io/kueue/kueue-must-gather-rhel9@sha256:a9b1535706a653954818c28bad4906cd61cfaa984925b7e9928098686ae1a413"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/kueue/kueue-operator-bundle@sha256:eff8cc23c2f37ba4c1a27a622aa87ae0ad3190b95b5c78b064f0605249c6189a"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/kueue/kueue-rhel9-operator@sha256:2f2fe648085540fa762417c941046abe6815972c577fea11b0292063c4bf3610"
+        },
+        {
+            "name": "operand-image",
+            "image": "registry.redhat.io/kueue/kueue-rhel9@sha256:35df4246eddb9444f30e595ff6f40ed8b1f040df7a13c547074100120398808c"
         }
     ]
 }

--- a/v4.19/catalog-template.yaml
+++ b/v4.19/catalog-template.yaml
@@ -13,3 +13,4 @@ Stable:
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:005047a1a84c92358df9736f9661136e185b1b9d4d9a2eeeb322aa6cb61d63a1
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:c26330443adc06876f5cc55952f78c7247a16bf577cc39d3e55eb3b695412361
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:c3e536c99c8ccb6777561d53a5af07bf604e9ddbf945fa430e91c0c10dd3aaf0
+  - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:eff8cc23c2f37ba4c1a27a622aa87ae0ad3190b95b5c78b064f0605249c6189a

--- a/v4.19/catalog/kueue-operator/catalog.json
+++ b/v4.19/catalog/kueue-operator/catalog.json
@@ -1,7 +1,7 @@
 {
     "schema": "olm.package",
     "name": "kueue-operator",
-    "defaultChannel": "stable-v1.3"
+    "defaultChannel": "stable-v1.4"
 }
 {
     "schema": "olm.channel",
@@ -78,6 +78,17 @@
             "skips": [
                 "kueue-operator.v1.3.0"
             ]
+        }
+    ]
+}
+
+{
+    "schema": "olm.channel",
+    "name": "stable-v1.4",
+    "package": "kueue-operator",
+    "entries": [
+        {
+            "name": "kueue-operator.v1.4.0"
         }
     ]
 }
@@ -1162,6 +1173,132 @@
         {
             "name": "operand-image",
             "image": "registry.redhat.io/kueue/kueue-rhel9@sha256:9ad4355bb1ae356b239f3517a56a21c0ef5979c78ea8eebc936eee5c42560acc"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "kueue-operator.v1.4.0",
+    "package": "kueue-operator",
+    "image": "registry.redhat.io/kueue/kueue-operator-bundle@sha256:eff8cc23c2f37ba4c1a27a622aa87ae0ad3190b95b5c78b064f0605249c6189a",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "kueue.openshift.io",
+                "kind": "Kueue",
+                "version": "v1"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "kueue-operator",
+                "version": "1.4.0"
+            }
+        },
+        {
+            "type": "olm.csv.metadata",
+            "value": {
+                "annotations": {
+                    "alm-examples": "[\n  {\n    \"apiVersion\": \"kueue.openshift.io/v1\",\n    \"kind\": \"Kueue\",\n    \"metadata\": {\n      \"labels\": {\n        \"app.kubernetes.io/managed-by\": \"kustomize\",\n        \"app.kubernetes.io/name\": \"kueue-operator\"\n      },\n      \"name\": \"cluster\"\n    },\n    \"spec\": {\n      \"config\": {\n        \"integrations\": {\n          \"frameworks\": [\n            \"BatchJob\"\n          ]\n        }\n      },\n      \"managementState\": \"Managed\"\n    }\n  }\n]",
+                    "capabilities": "Basic Install",
+                    "console.openshift.io/operator-monitoring-default": "true",
+                    "createdAt": "2026-06-12T20:43:50Z",
+                    "features.operators.openshift.io/cnf": "false",
+                    "features.operators.openshift.io/cni": "false",
+                    "features.operators.openshift.io/csi": "false",
+                    "features.operators.openshift.io/disconnected": "true",
+                    "features.operators.openshift.io/fips-compliant": "true",
+                    "features.operators.openshift.io/proxy-aware": "false",
+                    "features.operators.openshift.io/tls-profiles": "true",
+                    "features.operators.openshift.io/token-auth-aws": "false",
+                    "features.operators.openshift.io/token-auth-azure": "false",
+                    "features.operators.openshift.io/token-auth-gcp": "false",
+                    "operatorframework.io/cluster-monitoring": "true",
+                    "operatorframework.io/suggested-namespace": "openshift-kueue-operator",
+                    "operators.openshift.io/valid-subscription": "[\"OpenShift Kubernetes Engine\", \"OpenShift Container Platform\", \"OpenShift Platform Plus\"]",
+                    "operators.operatorframework.io/builder": "operator-sdk-v1.37.0",
+                    "operators.operatorframework.io/project_layout": "go.kubebuilder.io/v4"
+                },
+                "apiServiceDefinitions": {},
+                "crdDescriptions": {
+                    "owned": [
+                        {
+                            "name": "kueues.kueue.openshift.io",
+                            "version": "v1",
+                            "kind": "Kueue",
+                            "displayName": "Kueue",
+                            "description": "Kueue is a cluster resource for configuration of the Kueue operand"
+                        }
+                    ]
+                },
+                "description": "Red Hat build of Kueue is a collection of APIs, based on the [Kueue](https://kueue.sigs.k8s.io/docs/) open source project, that extends Kubernetes to manage access to resources for jobs. Red Hat build of Kueue does not replace any existing components in a Kubernetes cluster, but instead integrates with the existing Kubernetes API server, scheduler, and cluster autoscaler components to determine when a job waits, is admitted to start by creating pods, or should be preempted.",
+                "displayName": "Red Hat build of Kueue",
+                "installModes": [
+                    {
+                        "type": "OwnNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "SingleNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "MultiNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "AllNamespaces",
+                        "supported": true
+                    }
+                ],
+                "keywords": [
+                    "kueue-operator"
+                ],
+                "labels": {
+                    "operatorframework.io/arch.amd64": "supported",
+                    "operatorframework.io/arch.arm64": "supported",
+                    "operatorframework.io/arch.ppc64le": "supported",
+                    "operatorframework.io/arch.s390x": "supported"
+                },
+                "links": [
+                    {
+                        "name": "Kueue Operator",
+                        "url": "https://github.com/openshift/kueue-operator"
+                    }
+                ],
+                "maintainers": [
+                    {
+                        "name": "Node team",
+                        "email": "aos-node@redhat.com"
+                    }
+                ],
+                "maturity": "stable",
+                "minKubeVersion": "1.28.0",
+                "provider": {
+                    "name": "Red Hat, Inc",
+                    "url": "https://github.com/openshift/kueue-operator"
+                }
+            }
+        }
+    ],
+    "relatedImages": [
+        {
+            "name": "must-gather",
+            "image": "registry.redhat.io/kueue/kueue-must-gather-rhel9@sha256:a9b1535706a653954818c28bad4906cd61cfaa984925b7e9928098686ae1a413"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/kueue/kueue-operator-bundle@sha256:eff8cc23c2f37ba4c1a27a622aa87ae0ad3190b95b5c78b064f0605249c6189a"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/kueue/kueue-rhel9-operator@sha256:2f2fe648085540fa762417c941046abe6815972c577fea11b0292063c4bf3610"
+        },
+        {
+            "name": "operand-image",
+            "image": "registry.redhat.io/kueue/kueue-rhel9@sha256:35df4246eddb9444f30e595ff6f40ed8b1f040df7a13c547074100120398808c"
         }
     ]
 }

--- a/v4.20/catalog-template.yaml
+++ b/v4.20/catalog-template.yaml
@@ -8,3 +8,4 @@ Stable:
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:005047a1a84c92358df9736f9661136e185b1b9d4d9a2eeeb322aa6cb61d63a1
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:c26330443adc06876f5cc55952f78c7247a16bf577cc39d3e55eb3b695412361
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:c3e536c99c8ccb6777561d53a5af07bf604e9ddbf945fa430e91c0c10dd3aaf0
+  - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:eff8cc23c2f37ba4c1a27a622aa87ae0ad3190b95b5c78b064f0605249c6189a

--- a/v4.20/catalog/kueue-operator/catalog.json
+++ b/v4.20/catalog/kueue-operator/catalog.json
@@ -1,7 +1,7 @@
 {
     "schema": "olm.package",
     "name": "kueue-operator",
-    "defaultChannel": "stable-v1.3"
+    "defaultChannel": "stable-v1.4"
 }
 {
     "schema": "olm.channel",
@@ -36,6 +36,17 @@
             "skips": [
                 "kueue-operator.v1.3.0"
             ]
+        }
+    ]
+}
+
+{
+    "schema": "olm.channel",
+    "name": "stable-v1.4",
+    "package": "kueue-operator",
+    "entries": [
+        {
+            "name": "kueue-operator.v1.4.0"
         }
     ]
 }
@@ -538,6 +549,132 @@
         {
             "name": "operand-image",
             "image": "registry.redhat.io/kueue/kueue-rhel9@sha256:9ad4355bb1ae356b239f3517a56a21c0ef5979c78ea8eebc936eee5c42560acc"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "kueue-operator.v1.4.0",
+    "package": "kueue-operator",
+    "image": "registry.redhat.io/kueue/kueue-operator-bundle@sha256:eff8cc23c2f37ba4c1a27a622aa87ae0ad3190b95b5c78b064f0605249c6189a",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "kueue.openshift.io",
+                "kind": "Kueue",
+                "version": "v1"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "kueue-operator",
+                "version": "1.4.0"
+            }
+        },
+        {
+            "type": "olm.csv.metadata",
+            "value": {
+                "annotations": {
+                    "alm-examples": "[\n  {\n    \"apiVersion\": \"kueue.openshift.io/v1\",\n    \"kind\": \"Kueue\",\n    \"metadata\": {\n      \"labels\": {\n        \"app.kubernetes.io/managed-by\": \"kustomize\",\n        \"app.kubernetes.io/name\": \"kueue-operator\"\n      },\n      \"name\": \"cluster\"\n    },\n    \"spec\": {\n      \"config\": {\n        \"integrations\": {\n          \"frameworks\": [\n            \"BatchJob\"\n          ]\n        }\n      },\n      \"managementState\": \"Managed\"\n    }\n  }\n]",
+                    "capabilities": "Basic Install",
+                    "console.openshift.io/operator-monitoring-default": "true",
+                    "createdAt": "2026-06-12T20:43:50Z",
+                    "features.operators.openshift.io/cnf": "false",
+                    "features.operators.openshift.io/cni": "false",
+                    "features.operators.openshift.io/csi": "false",
+                    "features.operators.openshift.io/disconnected": "true",
+                    "features.operators.openshift.io/fips-compliant": "true",
+                    "features.operators.openshift.io/proxy-aware": "false",
+                    "features.operators.openshift.io/tls-profiles": "true",
+                    "features.operators.openshift.io/token-auth-aws": "false",
+                    "features.operators.openshift.io/token-auth-azure": "false",
+                    "features.operators.openshift.io/token-auth-gcp": "false",
+                    "operatorframework.io/cluster-monitoring": "true",
+                    "operatorframework.io/suggested-namespace": "openshift-kueue-operator",
+                    "operators.openshift.io/valid-subscription": "[\"OpenShift Kubernetes Engine\", \"OpenShift Container Platform\", \"OpenShift Platform Plus\"]",
+                    "operators.operatorframework.io/builder": "operator-sdk-v1.37.0",
+                    "operators.operatorframework.io/project_layout": "go.kubebuilder.io/v4"
+                },
+                "apiServiceDefinitions": {},
+                "crdDescriptions": {
+                    "owned": [
+                        {
+                            "name": "kueues.kueue.openshift.io",
+                            "version": "v1",
+                            "kind": "Kueue",
+                            "displayName": "Kueue",
+                            "description": "Kueue is a cluster resource for configuration of the Kueue operand"
+                        }
+                    ]
+                },
+                "description": "Red Hat build of Kueue is a collection of APIs, based on the [Kueue](https://kueue.sigs.k8s.io/docs/) open source project, that extends Kubernetes to manage access to resources for jobs. Red Hat build of Kueue does not replace any existing components in a Kubernetes cluster, but instead integrates with the existing Kubernetes API server, scheduler, and cluster autoscaler components to determine when a job waits, is admitted to start by creating pods, or should be preempted.",
+                "displayName": "Red Hat build of Kueue",
+                "installModes": [
+                    {
+                        "type": "OwnNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "SingleNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "MultiNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "AllNamespaces",
+                        "supported": true
+                    }
+                ],
+                "keywords": [
+                    "kueue-operator"
+                ],
+                "labels": {
+                    "operatorframework.io/arch.amd64": "supported",
+                    "operatorframework.io/arch.arm64": "supported",
+                    "operatorframework.io/arch.ppc64le": "supported",
+                    "operatorframework.io/arch.s390x": "supported"
+                },
+                "links": [
+                    {
+                        "name": "Kueue Operator",
+                        "url": "https://github.com/openshift/kueue-operator"
+                    }
+                ],
+                "maintainers": [
+                    {
+                        "name": "Node team",
+                        "email": "aos-node@redhat.com"
+                    }
+                ],
+                "maturity": "stable",
+                "minKubeVersion": "1.28.0",
+                "provider": {
+                    "name": "Red Hat, Inc",
+                    "url": "https://github.com/openshift/kueue-operator"
+                }
+            }
+        }
+    ],
+    "relatedImages": [
+        {
+            "name": "must-gather",
+            "image": "registry.redhat.io/kueue/kueue-must-gather-rhel9@sha256:a9b1535706a653954818c28bad4906cd61cfaa984925b7e9928098686ae1a413"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/kueue/kueue-operator-bundle@sha256:eff8cc23c2f37ba4c1a27a622aa87ae0ad3190b95b5c78b064f0605249c6189a"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/kueue/kueue-rhel9-operator@sha256:2f2fe648085540fa762417c941046abe6815972c577fea11b0292063c4bf3610"
+        },
+        {
+            "name": "operand-image",
+            "image": "registry.redhat.io/kueue/kueue-rhel9@sha256:35df4246eddb9444f30e595ff6f40ed8b1f040df7a13c547074100120398808c"
         }
     ]
 }

--- a/v4.21/catalog-template.yaml
+++ b/v4.21/catalog-template.yaml
@@ -7,3 +7,4 @@ Stable:
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:005047a1a84c92358df9736f9661136e185b1b9d4d9a2eeeb322aa6cb61d63a1
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:c26330443adc06876f5cc55952f78c7247a16bf577cc39d3e55eb3b695412361
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:c3e536c99c8ccb6777561d53a5af07bf604e9ddbf945fa430e91c0c10dd3aaf0
+  - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:eff8cc23c2f37ba4c1a27a622aa87ae0ad3190b95b5c78b064f0605249c6189a

--- a/v4.21/catalog/kueue-operator/catalog.json
+++ b/v4.21/catalog/kueue-operator/catalog.json
@@ -1,7 +1,7 @@
 {
     "schema": "olm.package",
     "name": "kueue-operator",
-    "defaultChannel": "stable-v1.3"
+    "defaultChannel": "stable-v1.4"
 }
 {
     "schema": "olm.channel",
@@ -26,6 +26,17 @@
             "skips": [
                 "kueue-operator.v1.3.0"
             ]
+        }
+    ]
+}
+
+{
+    "schema": "olm.channel",
+    "name": "stable-v1.4",
+    "package": "kueue-operator",
+    "entries": [
+        {
+            "name": "kueue-operator.v1.4.0"
         }
     ]
 }
@@ -404,6 +415,132 @@
         {
             "name": "operand-image",
             "image": "registry.redhat.io/kueue/kueue-rhel9@sha256:9ad4355bb1ae356b239f3517a56a21c0ef5979c78ea8eebc936eee5c42560acc"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "kueue-operator.v1.4.0",
+    "package": "kueue-operator",
+    "image": "registry.redhat.io/kueue/kueue-operator-bundle@sha256:eff8cc23c2f37ba4c1a27a622aa87ae0ad3190b95b5c78b064f0605249c6189a",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "kueue.openshift.io",
+                "kind": "Kueue",
+                "version": "v1"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "kueue-operator",
+                "version": "1.4.0"
+            }
+        },
+        {
+            "type": "olm.csv.metadata",
+            "value": {
+                "annotations": {
+                    "alm-examples": "[\n  {\n    \"apiVersion\": \"kueue.openshift.io/v1\",\n    \"kind\": \"Kueue\",\n    \"metadata\": {\n      \"labels\": {\n        \"app.kubernetes.io/managed-by\": \"kustomize\",\n        \"app.kubernetes.io/name\": \"kueue-operator\"\n      },\n      \"name\": \"cluster\"\n    },\n    \"spec\": {\n      \"config\": {\n        \"integrations\": {\n          \"frameworks\": [\n            \"BatchJob\"\n          ]\n        }\n      },\n      \"managementState\": \"Managed\"\n    }\n  }\n]",
+                    "capabilities": "Basic Install",
+                    "console.openshift.io/operator-monitoring-default": "true",
+                    "createdAt": "2026-06-12T20:43:50Z",
+                    "features.operators.openshift.io/cnf": "false",
+                    "features.operators.openshift.io/cni": "false",
+                    "features.operators.openshift.io/csi": "false",
+                    "features.operators.openshift.io/disconnected": "true",
+                    "features.operators.openshift.io/fips-compliant": "true",
+                    "features.operators.openshift.io/proxy-aware": "false",
+                    "features.operators.openshift.io/tls-profiles": "true",
+                    "features.operators.openshift.io/token-auth-aws": "false",
+                    "features.operators.openshift.io/token-auth-azure": "false",
+                    "features.operators.openshift.io/token-auth-gcp": "false",
+                    "operatorframework.io/cluster-monitoring": "true",
+                    "operatorframework.io/suggested-namespace": "openshift-kueue-operator",
+                    "operators.openshift.io/valid-subscription": "[\"OpenShift Kubernetes Engine\", \"OpenShift Container Platform\", \"OpenShift Platform Plus\"]",
+                    "operators.operatorframework.io/builder": "operator-sdk-v1.37.0",
+                    "operators.operatorframework.io/project_layout": "go.kubebuilder.io/v4"
+                },
+                "apiServiceDefinitions": {},
+                "crdDescriptions": {
+                    "owned": [
+                        {
+                            "name": "kueues.kueue.openshift.io",
+                            "version": "v1",
+                            "kind": "Kueue",
+                            "displayName": "Kueue",
+                            "description": "Kueue is a cluster resource for configuration of the Kueue operand"
+                        }
+                    ]
+                },
+                "description": "Red Hat build of Kueue is a collection of APIs, based on the [Kueue](https://kueue.sigs.k8s.io/docs/) open source project, that extends Kubernetes to manage access to resources for jobs. Red Hat build of Kueue does not replace any existing components in a Kubernetes cluster, but instead integrates with the existing Kubernetes API server, scheduler, and cluster autoscaler components to determine when a job waits, is admitted to start by creating pods, or should be preempted.",
+                "displayName": "Red Hat build of Kueue",
+                "installModes": [
+                    {
+                        "type": "OwnNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "SingleNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "MultiNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "AllNamespaces",
+                        "supported": true
+                    }
+                ],
+                "keywords": [
+                    "kueue-operator"
+                ],
+                "labels": {
+                    "operatorframework.io/arch.amd64": "supported",
+                    "operatorframework.io/arch.arm64": "supported",
+                    "operatorframework.io/arch.ppc64le": "supported",
+                    "operatorframework.io/arch.s390x": "supported"
+                },
+                "links": [
+                    {
+                        "name": "Kueue Operator",
+                        "url": "https://github.com/openshift/kueue-operator"
+                    }
+                ],
+                "maintainers": [
+                    {
+                        "name": "Node team",
+                        "email": "aos-node@redhat.com"
+                    }
+                ],
+                "maturity": "stable",
+                "minKubeVersion": "1.28.0",
+                "provider": {
+                    "name": "Red Hat, Inc",
+                    "url": "https://github.com/openshift/kueue-operator"
+                }
+            }
+        }
+    ],
+    "relatedImages": [
+        {
+            "name": "must-gather",
+            "image": "registry.redhat.io/kueue/kueue-must-gather-rhel9@sha256:a9b1535706a653954818c28bad4906cd61cfaa984925b7e9928098686ae1a413"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/kueue/kueue-operator-bundle@sha256:eff8cc23c2f37ba4c1a27a622aa87ae0ad3190b95b5c78b064f0605249c6189a"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/kueue/kueue-rhel9-operator@sha256:2f2fe648085540fa762417c941046abe6815972c577fea11b0292063c4bf3610"
+        },
+        {
+            "name": "operand-image",
+            "image": "registry.redhat.io/kueue/kueue-rhel9@sha256:35df4246eddb9444f30e595ff6f40ed8b1f040df7a13c547074100120398808c"
         }
     ]
 }

--- a/v4.22/catalog-template.yaml
+++ b/v4.22/catalog-template.yaml
@@ -5,3 +5,4 @@ DefaultChannelTypePreference: "minor"
 Stable:
   Bundles:
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:c3e536c99c8ccb6777561d53a5af07bf604e9ddbf945fa430e91c0c10dd3aaf0
+  - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:eff8cc23c2f37ba4c1a27a622aa87ae0ad3190b95b5c78b064f0605249c6189a

--- a/v4.22/catalog/kueue-operator/catalog.json
+++ b/v4.22/catalog/kueue-operator/catalog.json
@@ -1,7 +1,7 @@
 {
     "schema": "olm.package",
     "name": "kueue-operator",
-    "defaultChannel": "stable-v1.3"
+    "defaultChannel": "stable-v1.4"
 }
 {
     "schema": "olm.channel",
@@ -10,6 +10,17 @@
     "entries": [
         {
             "name": "kueue-operator.v1.3.1"
+        }
+    ]
+}
+
+{
+    "schema": "olm.channel",
+    "name": "stable-v1.4",
+    "package": "kueue-operator",
+    "entries": [
+        {
+            "name": "kueue-operator.v1.4.0"
         }
     ]
 }
@@ -136,6 +147,132 @@
         {
             "name": "operand-image",
             "image": "registry.redhat.io/kueue/kueue-rhel9@sha256:9ad4355bb1ae356b239f3517a56a21c0ef5979c78ea8eebc936eee5c42560acc"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "kueue-operator.v1.4.0",
+    "package": "kueue-operator",
+    "image": "registry.redhat.io/kueue/kueue-operator-bundle@sha256:eff8cc23c2f37ba4c1a27a622aa87ae0ad3190b95b5c78b064f0605249c6189a",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "kueue.openshift.io",
+                "kind": "Kueue",
+                "version": "v1"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "kueue-operator",
+                "version": "1.4.0"
+            }
+        },
+        {
+            "type": "olm.csv.metadata",
+            "value": {
+                "annotations": {
+                    "alm-examples": "[\n  {\n    \"apiVersion\": \"kueue.openshift.io/v1\",\n    \"kind\": \"Kueue\",\n    \"metadata\": {\n      \"labels\": {\n        \"app.kubernetes.io/managed-by\": \"kustomize\",\n        \"app.kubernetes.io/name\": \"kueue-operator\"\n      },\n      \"name\": \"cluster\"\n    },\n    \"spec\": {\n      \"config\": {\n        \"integrations\": {\n          \"frameworks\": [\n            \"BatchJob\"\n          ]\n        }\n      },\n      \"managementState\": \"Managed\"\n    }\n  }\n]",
+                    "capabilities": "Basic Install",
+                    "console.openshift.io/operator-monitoring-default": "true",
+                    "createdAt": "2026-06-12T20:43:50Z",
+                    "features.operators.openshift.io/cnf": "false",
+                    "features.operators.openshift.io/cni": "false",
+                    "features.operators.openshift.io/csi": "false",
+                    "features.operators.openshift.io/disconnected": "true",
+                    "features.operators.openshift.io/fips-compliant": "true",
+                    "features.operators.openshift.io/proxy-aware": "false",
+                    "features.operators.openshift.io/tls-profiles": "true",
+                    "features.operators.openshift.io/token-auth-aws": "false",
+                    "features.operators.openshift.io/token-auth-azure": "false",
+                    "features.operators.openshift.io/token-auth-gcp": "false",
+                    "operatorframework.io/cluster-monitoring": "true",
+                    "operatorframework.io/suggested-namespace": "openshift-kueue-operator",
+                    "operators.openshift.io/valid-subscription": "[\"OpenShift Kubernetes Engine\", \"OpenShift Container Platform\", \"OpenShift Platform Plus\"]",
+                    "operators.operatorframework.io/builder": "operator-sdk-v1.37.0",
+                    "operators.operatorframework.io/project_layout": "go.kubebuilder.io/v4"
+                },
+                "apiServiceDefinitions": {},
+                "crdDescriptions": {
+                    "owned": [
+                        {
+                            "name": "kueues.kueue.openshift.io",
+                            "version": "v1",
+                            "kind": "Kueue",
+                            "displayName": "Kueue",
+                            "description": "Kueue is a cluster resource for configuration of the Kueue operand"
+                        }
+                    ]
+                },
+                "description": "Red Hat build of Kueue is a collection of APIs, based on the [Kueue](https://kueue.sigs.k8s.io/docs/) open source project, that extends Kubernetes to manage access to resources for jobs. Red Hat build of Kueue does not replace any existing components in a Kubernetes cluster, but instead integrates with the existing Kubernetes API server, scheduler, and cluster autoscaler components to determine when a job waits, is admitted to start by creating pods, or should be preempted.",
+                "displayName": "Red Hat build of Kueue",
+                "installModes": [
+                    {
+                        "type": "OwnNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "SingleNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "MultiNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "AllNamespaces",
+                        "supported": true
+                    }
+                ],
+                "keywords": [
+                    "kueue-operator"
+                ],
+                "labels": {
+                    "operatorframework.io/arch.amd64": "supported",
+                    "operatorframework.io/arch.arm64": "supported",
+                    "operatorframework.io/arch.ppc64le": "supported",
+                    "operatorframework.io/arch.s390x": "supported"
+                },
+                "links": [
+                    {
+                        "name": "Kueue Operator",
+                        "url": "https://github.com/openshift/kueue-operator"
+                    }
+                ],
+                "maintainers": [
+                    {
+                        "name": "Node team",
+                        "email": "aos-node@redhat.com"
+                    }
+                ],
+                "maturity": "stable",
+                "minKubeVersion": "1.28.0",
+                "provider": {
+                    "name": "Red Hat, Inc",
+                    "url": "https://github.com/openshift/kueue-operator"
+                }
+            }
+        }
+    ],
+    "relatedImages": [
+        {
+            "name": "must-gather",
+            "image": "registry.redhat.io/kueue/kueue-must-gather-rhel9@sha256:a9b1535706a653954818c28bad4906cd61cfaa984925b7e9928098686ae1a413"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/kueue/kueue-operator-bundle@sha256:eff8cc23c2f37ba4c1a27a622aa87ae0ad3190b95b5c78b064f0605249c6189a"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/kueue/kueue-rhel9-operator@sha256:2f2fe648085540fa762417c941046abe6815972c577fea11b0292063c4bf3610"
+        },
+        {
+            "name": "operand-image",
+            "image": "registry.redhat.io/kueue/kueue-rhel9@sha256:35df4246eddb9444f30e595ff6f40ed8b1f040df7a13c547074100120398808c"
         }
     ]
 }

--- a/v5.0/catalog-template.yaml
+++ b/v5.0/catalog-template.yaml
@@ -5,3 +5,4 @@ DefaultChannelTypePreference: "minor"
 Stable:
   Bundles:
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:c3e536c99c8ccb6777561d53a5af07bf604e9ddbf945fa430e91c0c10dd3aaf0
+  - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:eff8cc23c2f37ba4c1a27a622aa87ae0ad3190b95b5c78b064f0605249c6189a

--- a/v5.0/catalog/kueue-operator/catalog.json
+++ b/v5.0/catalog/kueue-operator/catalog.json
@@ -1,7 +1,7 @@
 {
     "schema": "olm.package",
     "name": "kueue-operator",
-    "defaultChannel": "stable-v1.3"
+    "defaultChannel": "stable-v1.4"
 }
 {
     "schema": "olm.channel",
@@ -10,6 +10,17 @@
     "entries": [
         {
             "name": "kueue-operator.v1.3.1"
+        }
+    ]
+}
+
+{
+    "schema": "olm.channel",
+    "name": "stable-v1.4",
+    "package": "kueue-operator",
+    "entries": [
+        {
+            "name": "kueue-operator.v1.4.0"
         }
     ]
 }
@@ -136,6 +147,132 @@
         {
             "name": "operand-image",
             "image": "registry.redhat.io/kueue/kueue-rhel9@sha256:9ad4355bb1ae356b239f3517a56a21c0ef5979c78ea8eebc936eee5c42560acc"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "kueue-operator.v1.4.0",
+    "package": "kueue-operator",
+    "image": "registry.redhat.io/kueue/kueue-operator-bundle@sha256:eff8cc23c2f37ba4c1a27a622aa87ae0ad3190b95b5c78b064f0605249c6189a",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "kueue.openshift.io",
+                "kind": "Kueue",
+                "version": "v1"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "kueue-operator",
+                "version": "1.4.0"
+            }
+        },
+        {
+            "type": "olm.csv.metadata",
+            "value": {
+                "annotations": {
+                    "alm-examples": "[\n  {\n    \"apiVersion\": \"kueue.openshift.io/v1\",\n    \"kind\": \"Kueue\",\n    \"metadata\": {\n      \"labels\": {\n        \"app.kubernetes.io/managed-by\": \"kustomize\",\n        \"app.kubernetes.io/name\": \"kueue-operator\"\n      },\n      \"name\": \"cluster\"\n    },\n    \"spec\": {\n      \"config\": {\n        \"integrations\": {\n          \"frameworks\": [\n            \"BatchJob\"\n          ]\n        }\n      },\n      \"managementState\": \"Managed\"\n    }\n  }\n]",
+                    "capabilities": "Basic Install",
+                    "console.openshift.io/operator-monitoring-default": "true",
+                    "createdAt": "2026-06-12T20:43:50Z",
+                    "features.operators.openshift.io/cnf": "false",
+                    "features.operators.openshift.io/cni": "false",
+                    "features.operators.openshift.io/csi": "false",
+                    "features.operators.openshift.io/disconnected": "true",
+                    "features.operators.openshift.io/fips-compliant": "true",
+                    "features.operators.openshift.io/proxy-aware": "false",
+                    "features.operators.openshift.io/tls-profiles": "true",
+                    "features.operators.openshift.io/token-auth-aws": "false",
+                    "features.operators.openshift.io/token-auth-azure": "false",
+                    "features.operators.openshift.io/token-auth-gcp": "false",
+                    "operatorframework.io/cluster-monitoring": "true",
+                    "operatorframework.io/suggested-namespace": "openshift-kueue-operator",
+                    "operators.openshift.io/valid-subscription": "[\"OpenShift Kubernetes Engine\", \"OpenShift Container Platform\", \"OpenShift Platform Plus\"]",
+                    "operators.operatorframework.io/builder": "operator-sdk-v1.37.0",
+                    "operators.operatorframework.io/project_layout": "go.kubebuilder.io/v4"
+                },
+                "apiServiceDefinitions": {},
+                "crdDescriptions": {
+                    "owned": [
+                        {
+                            "name": "kueues.kueue.openshift.io",
+                            "version": "v1",
+                            "kind": "Kueue",
+                            "displayName": "Kueue",
+                            "description": "Kueue is a cluster resource for configuration of the Kueue operand"
+                        }
+                    ]
+                },
+                "description": "Red Hat build of Kueue is a collection of APIs, based on the [Kueue](https://kueue.sigs.k8s.io/docs/) open source project, that extends Kubernetes to manage access to resources for jobs. Red Hat build of Kueue does not replace any existing components in a Kubernetes cluster, but instead integrates with the existing Kubernetes API server, scheduler, and cluster autoscaler components to determine when a job waits, is admitted to start by creating pods, or should be preempted.",
+                "displayName": "Red Hat build of Kueue",
+                "installModes": [
+                    {
+                        "type": "OwnNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "SingleNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "MultiNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "AllNamespaces",
+                        "supported": true
+                    }
+                ],
+                "keywords": [
+                    "kueue-operator"
+                ],
+                "labels": {
+                    "operatorframework.io/arch.amd64": "supported",
+                    "operatorframework.io/arch.arm64": "supported",
+                    "operatorframework.io/arch.ppc64le": "supported",
+                    "operatorframework.io/arch.s390x": "supported"
+                },
+                "links": [
+                    {
+                        "name": "Kueue Operator",
+                        "url": "https://github.com/openshift/kueue-operator"
+                    }
+                ],
+                "maintainers": [
+                    {
+                        "name": "Node team",
+                        "email": "aos-node@redhat.com"
+                    }
+                ],
+                "maturity": "stable",
+                "minKubeVersion": "1.28.0",
+                "provider": {
+                    "name": "Red Hat, Inc",
+                    "url": "https://github.com/openshift/kueue-operator"
+                }
+            }
+        }
+    ],
+    "relatedImages": [
+        {
+            "name": "must-gather",
+            "image": "registry.redhat.io/kueue/kueue-must-gather-rhel9@sha256:a9b1535706a653954818c28bad4906cd61cfaa984925b7e9928098686ae1a413"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/kueue/kueue-operator-bundle@sha256:eff8cc23c2f37ba4c1a27a622aa87ae0ad3190b95b5c78b064f0605249c6189a"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/kueue/kueue-rhel9-operator@sha256:2f2fe648085540fa762417c941046abe6815972c577fea11b0292063c4bf3610"
+        },
+        {
+            "name": "operand-image",
+            "image": "registry.redhat.io/kueue/kueue-rhel9@sha256:35df4246eddb9444f30e595ff6f40ed8b1f040df7a13c547074100120398808c"
         }
     ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kueue Operator v1.4.0 to the stable catalog across supported catalog versions.
  * Updated the default channel from stable-v1.3 to stable-v1.4.
  * Added refreshed bundle metadata, supported feature flags, and related image references.
  * Updated stable bundle image references to include the v1.4.0 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->