### PR TITLE
add a command to validate if release are in the catalog

### DIFF
--- a/.claude/commands/validate-releases.md
+++ b/.claude/commands/validate-releases.md
@@ -1,0 +1,17 @@
+Validate that the latest kueue-operator release has actually shipped to Red Hat's operator index for every OCP version we support:
+
+```bash
+./validate-releases.sh
+```
+
+This script:
+- Determines the latest kueue-operator bundle version from this repo's own catalogs (the newest version directory's `catalog.json`)
+- Runs `opm render registry.redhat.io/redhat/redhat-operator-index:v$OCP_VERSION` for each supported OCP version (derived from the `v*.*` directories in this repo)
+- Extracts the kueue-operator bundle versions present on each live index and compares the newest one against the expected latest version
+- Exits non-zero and lists any OCP version that is missing the package entirely or is behind the expected version
+
+Prerequisites:
+- `opm` (1.47.0+) and `jq` must be installed and on PATH
+- You must be logged in to `registry.redhat.io` (e.g. `podman login registry.redhat.io`) so `opm render` can pull the index images
+
+Run the script and summarize the results for the user, calling out any OCP version that isn't on the latest kueue-operator release.

--- a/validate-releases.sh
+++ b/validate-releases.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+#
+# Verify the latest kueue-operator bundle we ship is actually present on
+# registry.redhat.io/redhat/redhat-operator-index for every OCP version we support.
+#
+# Prerequisites: opm, jq, and registry.redhat.io pull access (podman/docker login).
+
+set -euo pipefail
+
+PACKAGE_NAME="kueue-operator"
+OCP_VERSIONS=($(find . -maxdepth 1 -type d -name 'v[0-9]*.[0-9]*' -printf '%f\n' | sed 's/^v//' | sort -V))
+
+bundle_versions() {
+    jq -r --arg pkg "$PACKAGE_NAME" \
+        'select(.schema=="olm.bundle" and .package==$pkg) | .properties[]? | select(.type=="olm.package") | .value.version'
+}
+
+latest_local_version() {
+    local latest_dir
+    latest_dir="v$(printf '%s\n' "${OCP_VERSIONS[@]}" | tail -1)"
+    bundle_versions < "$latest_dir/catalog/kueue-operator/catalog.json" | sort -V | tail -1
+}
+
+LATEST_VERSION=$(latest_local_version)
+echo "Latest kueue-operator version in this repo: $LATEST_VERSION"
+echo
+
+FAILED=()
+
+for OCP_VERSION in "${OCP_VERSIONS[@]}"; do
+    INDEX="registry.redhat.io/redhat/redhat-operator-index:v${OCP_VERSION}"
+    echo "Checking $PACKAGE_NAME on ${INDEX}..."
+
+    if ! VERSIONS=$(opm render "$INDEX" | bundle_versions | sort -V); then
+        echo "  ERROR: failed to render index for OCP ${OCP_VERSION}"
+        FAILED+=("${OCP_VERSION}: index render failed")
+        echo
+        continue
+    fi
+
+    if [ -z "$VERSIONS" ]; then
+        echo "  ERROR: no $PACKAGE_NAME bundles found on index for OCP ${OCP_VERSION}"
+        FAILED+=("${OCP_VERSION}: missing")
+        echo
+        continue
+    fi
+
+    echo "  versions found: $(echo "$VERSIONS" | tr '\n' ' ')"
+
+    if ! grep -Fxq "$LATEST_VERSION" <<< "$VERSIONS"; then
+        FOUND_LATEST=$(echo "$VERSIONS" | tail -1)
+        echo "  MISMATCH: expected version $LATEST_VERSION is absent; latest is $FOUND_LATEST"
+        FAILED+=("${OCP_VERSION}: missing ${LATEST_VERSION}, latest is ${FOUND_LATEST}")
+    else
+        echo "  OK"
+    fi
+    echo
+done
+
+if [ ${#FAILED[@]} -gt 0 ]; then
+    echo "FAILED:"
+    printf '  %s\n' "${FAILED[@]}"
+    exit 1
+fi
+
+echo "All catalogs have kueue-operator $LATEST_VERSION"


### PR DESCRIPTION
run ./validate-releases.sh

```
Latest kueue-operator version in this repo: 1.4.0

Checking kueue-operator on registry.redhat.io/redhat/redhat-operator-index:v4.18...
  versions found: 0.1.0 0.2.0 0.2.1 1.0.0 1.0.1 1.1.0 1.2.0 1.3.0 1.3.1 
  MISMATCH: latest on index is 1.3.1, expected 1.4.0

Checking kueue-operator on registry.redhat.io/redhat/redhat-operator-index:v4.19...
  versions found: 0.1.0 0.2.0 0.2.1 1.0.0 1.0.1 1.1.0 1.2.0 1.3.0 1.3.1 
  MISMATCH: latest on index is 1.3.1, expected 1.4.0

Checking kueue-operator on registry.redhat.io/redhat/redhat-operator-index:v4.20...
  versions found: 1.1.0 1.2.0 1.3.0 1.3.1 
  MISMATCH: latest on index is 1.3.1, expected 1.4.0

Checking kueue-operator on registry.redhat.io/redhat/redhat-operator-index:v4.21...
  versions found: 1.2.0 1.3.0 1.3.1 
  MISMATCH: latest on index is 1.3.1, expected 1.4.0

Checking kueue-operator on registry.redhat.io/redhat/redhat-operator-index:v4.22...
  versions found: 1.3.1 
  MISMATCH: latest on index is 1.3.1, expected 1.4.0

Checking kueue-operator on registry.redhat.io/redhat/redhat-operator-index:v5.0...
  ERROR: no kueue-operator bundles found on index for OCP 5.0

FAILED:
  4.18: found 1.3.1, want 1.4.0
  4.19: found 1.3.1, want 1.4.0
  4.20: found 1.3.1, want 1.4.0
  4.21: found 1.3.1, want 1.4.0
  4.22: found 1.3.1, want 1.4.0
  5.0: missing
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a release validation tool that compares the repository’s “latest” kueue-operator bundle version against Red Hat operator index bundles across all supported OCP versions.
  * Fails with a non-zero status when the latest bundle is missing, older than expected, or when the remote index can’t be rendered for an OCP version.
* **Documentation**
  * Added a new guide explaining how to run the validation script, expected behavior, required tooling, authentication prerequisites, and how to report OCP versions where the latest release is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->