### PR TITLE
fix get-snapshots.py to filter for push pipeline snapshots only

### DIFF
--- a/get-snapshots.py
+++ b/get-snapshots.py
@@ -37,7 +37,7 @@ def get_latest_snapshot(component):
         result = subprocess.run(
             [
                 KUBECTL, "get", "snapshots",
-                "-l", f"appstudio.openshift.io/component={component}",
+                "-l", f"appstudio.openshift.io/component={component},pac.test.appstudio.openshift.io/event-type=push",
                 "--sort-by=.metadata.creationTimestamp",
                 "-o", "json",
             ],


### PR DESCRIPTION
Without the event-type=push label filter, the script returns PR pipeline snapshots when they happen to be newer than push snapshots. PR snapshots have quay.expires-after labels that cause Conforma policy failures during release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Latest snapshot results now include only snapshots associated with push events for the matching component.
  * Improved accuracy of displayed snapshot names, creation dates, and container images by excluding unrelated snapshot types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->