### PR TITLE
add kueue 1.4.1

### DIFF
--- a/v4.18/catalog-template.yaml
+++ b/v4.18/catalog-template.yaml
@@ -14,3 +14,4 @@ Stable:
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:c26330443adc06876f5cc55952f78c7247a16bf577cc39d3e55eb3b695412361
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:c3e536c99c8ccb6777561d53a5af07bf604e9ddbf945fa430e91c0c10dd3aaf0
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:eff8cc23c2f37ba4c1a27a622aa87ae0ad3190b95b5c78b064f0605249c6189a
+  - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:2a2217f0277a39ccccaafc742c06d7b834ae1dd834d749c4b8ad0a4b5e2b01ce

--- a/v4.18/catalog/kueue-operator/catalog.json
+++ b/v4.18/catalog/kueue-operator/catalog.json
@@ -81,7 +81,6 @@
         }
     ]
 }
-
 {
     "schema": "olm.channel",
     "name": "stable-v1.4",
@@ -89,6 +88,12 @@
     "entries": [
         {
             "name": "kueue-operator.v1.4.0"
+        },
+        {
+            "name": "kueue-operator.v1.4.1",
+            "skips": [
+                "kueue-operator.v1.4.0"
+            ]
         }
     ]
 }
@@ -1299,6 +1304,132 @@
         {
             "name": "operand-image",
             "image": "registry.redhat.io/kueue/kueue-rhel9@sha256:35df4246eddb9444f30e595ff6f40ed8b1f040df7a13c547074100120398808c"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "kueue-operator.v1.4.1",
+    "package": "kueue-operator",
+    "image": "registry.redhat.io/kueue/kueue-operator-bundle@sha256:2a2217f0277a39ccccaafc742c06d7b834ae1dd834d749c4b8ad0a4b5e2b01ce",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "kueue.openshift.io",
+                "kind": "Kueue",
+                "version": "v1"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "kueue-operator",
+                "version": "1.4.1"
+            }
+        },
+        {
+            "type": "olm.csv.metadata",
+            "value": {
+                "annotations": {
+                    "alm-examples": "[\n  {\n    \"apiVersion\": \"kueue.openshift.io/v1\",\n    \"kind\": \"Kueue\",\n    \"metadata\": {\n      \"labels\": {\n        \"app.kubernetes.io/managed-by\": \"kustomize\",\n        \"app.kubernetes.io/name\": \"kueue-operator\"\n      },\n      \"name\": \"cluster\"\n    },\n    \"spec\": {\n      \"config\": {\n        \"integrations\": {\n          \"frameworks\": [\n            \"BatchJob\"\n          ]\n        }\n      },\n      \"managementState\": \"Managed\"\n    }\n  }\n]",
+                    "capabilities": "Basic Install",
+                    "console.openshift.io/operator-monitoring-default": "true",
+                    "createdAt": "2026-08-03T20:53:18Z",
+                    "features.operators.openshift.io/cnf": "false",
+                    "features.operators.openshift.io/cni": "false",
+                    "features.operators.openshift.io/csi": "false",
+                    "features.operators.openshift.io/disconnected": "true",
+                    "features.operators.openshift.io/fips-compliant": "true",
+                    "features.operators.openshift.io/proxy-aware": "false",
+                    "features.operators.openshift.io/tls-profiles": "true",
+                    "features.operators.openshift.io/token-auth-aws": "false",
+                    "features.operators.openshift.io/token-auth-azure": "false",
+                    "features.operators.openshift.io/token-auth-gcp": "false",
+                    "operatorframework.io/cluster-monitoring": "true",
+                    "operatorframework.io/suggested-namespace": "openshift-kueue-operator",
+                    "operators.openshift.io/valid-subscription": "[\"OpenShift Kubernetes Engine\", \"OpenShift Container Platform\", \"OpenShift Platform Plus\"]",
+                    "operators.operatorframework.io/builder": "operator-sdk-v1.37.0",
+                    "operators.operatorframework.io/project_layout": "go.kubebuilder.io/v4"
+                },
+                "apiServiceDefinitions": {},
+                "crdDescriptions": {
+                    "owned": [
+                        {
+                            "name": "kueues.kueue.openshift.io",
+                            "version": "v1",
+                            "kind": "Kueue",
+                            "displayName": "Kueue",
+                            "description": "Kueue is a cluster resource for configuration of the Kueue operand"
+                        }
+                    ]
+                },
+                "description": "Red Hat build of Kueue is a collection of APIs, based on the [Kueue](https://kueue.sigs.k8s.io/docs/) open source project, that extends Kubernetes to manage access to resources for jobs. Red Hat build of Kueue does not replace any existing components in a Kubernetes cluster, but instead integrates with the existing Kubernetes API server, scheduler, and cluster autoscaler components to determine when a job waits, is admitted to start by creating pods, or should be preempted.",
+                "displayName": "Red Hat build of Kueue",
+                "installModes": [
+                    {
+                        "type": "OwnNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "SingleNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "MultiNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "AllNamespaces",
+                        "supported": true
+                    }
+                ],
+                "keywords": [
+                    "kueue-operator"
+                ],
+                "labels": {
+                    "operatorframework.io/arch.amd64": "supported",
+                    "operatorframework.io/arch.arm64": "supported",
+                    "operatorframework.io/arch.ppc64le": "supported",
+                    "operatorframework.io/arch.s390x": "supported"
+                },
+                "links": [
+                    {
+                        "name": "Kueue Operator",
+                        "url": "https://github.com/openshift/kueue-operator"
+                    }
+                ],
+                "maintainers": [
+                    {
+                        "name": "Node team",
+                        "email": "aos-node@redhat.com"
+                    }
+                ],
+                "maturity": "stable",
+                "minKubeVersion": "1.28.0",
+                "provider": {
+                    "name": "Red Hat, Inc",
+                    "url": "https://github.com/openshift/kueue-operator"
+                }
+            }
+        }
+    ],
+    "relatedImages": [
+        {
+            "name": "must-gather",
+            "image": "registry.redhat.io/kueue/kueue-must-gather-rhel9@sha256:3ab73f249743cc48bc8e99dd776490c7bbb28f00b206f667ad0cd2558bce427b"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/kueue/kueue-operator-bundle@sha256:2a2217f0277a39ccccaafc742c06d7b834ae1dd834d749c4b8ad0a4b5e2b01ce"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/kueue/kueue-rhel9-operator@sha256:0cf6d39f8bf09c496123753b223ec5ff0b6234cd7b24b425b78d3cbf36e1aae9"
+        },
+        {
+            "name": "operand-image",
+            "image": "registry.redhat.io/kueue/kueue-rhel9@sha256:cdc406dab199d85bfb280b0f70bdd8a3865a46436bcd6ad72801343a281cabf4"
         }
     ]
 }

--- a/v4.19/catalog-template.yaml
+++ b/v4.19/catalog-template.yaml
@@ -14,3 +14,4 @@ Stable:
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:c26330443adc06876f5cc55952f78c7247a16bf577cc39d3e55eb3b695412361
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:c3e536c99c8ccb6777561d53a5af07bf604e9ddbf945fa430e91c0c10dd3aaf0
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:eff8cc23c2f37ba4c1a27a622aa87ae0ad3190b95b5c78b064f0605249c6189a
+  - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:2a2217f0277a39ccccaafc742c06d7b834ae1dd834d749c4b8ad0a4b5e2b01ce

--- a/v4.19/catalog/kueue-operator/catalog.json
+++ b/v4.19/catalog/kueue-operator/catalog.json
@@ -81,7 +81,6 @@
         }
     ]
 }
-
 {
     "schema": "olm.channel",
     "name": "stable-v1.4",
@@ -89,6 +88,12 @@
     "entries": [
         {
             "name": "kueue-operator.v1.4.0"
+        },
+        {
+            "name": "kueue-operator.v1.4.1",
+            "skips": [
+                "kueue-operator.v1.4.0"
+            ]
         }
     ]
 }
@@ -1299,6 +1304,132 @@
         {
             "name": "operand-image",
             "image": "registry.redhat.io/kueue/kueue-rhel9@sha256:35df4246eddb9444f30e595ff6f40ed8b1f040df7a13c547074100120398808c"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "kueue-operator.v1.4.1",
+    "package": "kueue-operator",
+    "image": "registry.redhat.io/kueue/kueue-operator-bundle@sha256:2a2217f0277a39ccccaafc742c06d7b834ae1dd834d749c4b8ad0a4b5e2b01ce",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "kueue.openshift.io",
+                "kind": "Kueue",
+                "version": "v1"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "kueue-operator",
+                "version": "1.4.1"
+            }
+        },
+        {
+            "type": "olm.csv.metadata",
+            "value": {
+                "annotations": {
+                    "alm-examples": "[\n  {\n    \"apiVersion\": \"kueue.openshift.io/v1\",\n    \"kind\": \"Kueue\",\n    \"metadata\": {\n      \"labels\": {\n        \"app.kubernetes.io/managed-by\": \"kustomize\",\n        \"app.kubernetes.io/name\": \"kueue-operator\"\n      },\n      \"name\": \"cluster\"\n    },\n    \"spec\": {\n      \"config\": {\n        \"integrations\": {\n          \"frameworks\": [\n            \"BatchJob\"\n          ]\n        }\n      },\n      \"managementState\": \"Managed\"\n    }\n  }\n]",
+                    "capabilities": "Basic Install",
+                    "console.openshift.io/operator-monitoring-default": "true",
+                    "createdAt": "2026-08-03T20:53:18Z",
+                    "features.operators.openshift.io/cnf": "false",
+                    "features.operators.openshift.io/cni": "false",
+                    "features.operators.openshift.io/csi": "false",
+                    "features.operators.openshift.io/disconnected": "true",
+                    "features.operators.openshift.io/fips-compliant": "true",
+                    "features.operators.openshift.io/proxy-aware": "false",
+                    "features.operators.openshift.io/tls-profiles": "true",
+                    "features.operators.openshift.io/token-auth-aws": "false",
+                    "features.operators.openshift.io/token-auth-azure": "false",
+                    "features.operators.openshift.io/token-auth-gcp": "false",
+                    "operatorframework.io/cluster-monitoring": "true",
+                    "operatorframework.io/suggested-namespace": "openshift-kueue-operator",
+                    "operators.openshift.io/valid-subscription": "[\"OpenShift Kubernetes Engine\", \"OpenShift Container Platform\", \"OpenShift Platform Plus\"]",
+                    "operators.operatorframework.io/builder": "operator-sdk-v1.37.0",
+                    "operators.operatorframework.io/project_layout": "go.kubebuilder.io/v4"
+                },
+                "apiServiceDefinitions": {},
+                "crdDescriptions": {
+                    "owned": [
+                        {
+                            "name": "kueues.kueue.openshift.io",
+                            "version": "v1",
+                            "kind": "Kueue",
+                            "displayName": "Kueue",
+                            "description": "Kueue is a cluster resource for configuration of the Kueue operand"
+                        }
+                    ]
+                },
+                "description": "Red Hat build of Kueue is a collection of APIs, based on the [Kueue](https://kueue.sigs.k8s.io/docs/) open source project, that extends Kubernetes to manage access to resources for jobs. Red Hat build of Kueue does not replace any existing components in a Kubernetes cluster, but instead integrates with the existing Kubernetes API server, scheduler, and cluster autoscaler components to determine when a job waits, is admitted to start by creating pods, or should be preempted.",
+                "displayName": "Red Hat build of Kueue",
+                "installModes": [
+                    {
+                        "type": "OwnNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "SingleNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "MultiNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "AllNamespaces",
+                        "supported": true
+                    }
+                ],
+                "keywords": [
+                    "kueue-operator"
+                ],
+                "labels": {
+                    "operatorframework.io/arch.amd64": "supported",
+                    "operatorframework.io/arch.arm64": "supported",
+                    "operatorframework.io/arch.ppc64le": "supported",
+                    "operatorframework.io/arch.s390x": "supported"
+                },
+                "links": [
+                    {
+                        "name": "Kueue Operator",
+                        "url": "https://github.com/openshift/kueue-operator"
+                    }
+                ],
+                "maintainers": [
+                    {
+                        "name": "Node team",
+                        "email": "aos-node@redhat.com"
+                    }
+                ],
+                "maturity": "stable",
+                "minKubeVersion": "1.28.0",
+                "provider": {
+                    "name": "Red Hat, Inc",
+                    "url": "https://github.com/openshift/kueue-operator"
+                }
+            }
+        }
+    ],
+    "relatedImages": [
+        {
+            "name": "must-gather",
+            "image": "registry.redhat.io/kueue/kueue-must-gather-rhel9@sha256:3ab73f249743cc48bc8e99dd776490c7bbb28f00b206f667ad0cd2558bce427b"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/kueue/kueue-operator-bundle@sha256:2a2217f0277a39ccccaafc742c06d7b834ae1dd834d749c4b8ad0a4b5e2b01ce"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/kueue/kueue-rhel9-operator@sha256:0cf6d39f8bf09c496123753b223ec5ff0b6234cd7b24b425b78d3cbf36e1aae9"
+        },
+        {
+            "name": "operand-image",
+            "image": "registry.redhat.io/kueue/kueue-rhel9@sha256:cdc406dab199d85bfb280b0f70bdd8a3865a46436bcd6ad72801343a281cabf4"
         }
     ]
 }

--- a/v4.20/catalog-template.yaml
+++ b/v4.20/catalog-template.yaml
@@ -9,3 +9,4 @@ Stable:
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:c26330443adc06876f5cc55952f78c7247a16bf577cc39d3e55eb3b695412361
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:c3e536c99c8ccb6777561d53a5af07bf604e9ddbf945fa430e91c0c10dd3aaf0
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:eff8cc23c2f37ba4c1a27a622aa87ae0ad3190b95b5c78b064f0605249c6189a
+  - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:2a2217f0277a39ccccaafc742c06d7b834ae1dd834d749c4b8ad0a4b5e2b01ce

--- a/v4.20/catalog/kueue-operator/catalog.json
+++ b/v4.20/catalog/kueue-operator/catalog.json
@@ -39,7 +39,6 @@
         }
     ]
 }
-
 {
     "schema": "olm.channel",
     "name": "stable-v1.4",
@@ -47,6 +46,12 @@
     "entries": [
         {
             "name": "kueue-operator.v1.4.0"
+        },
+        {
+            "name": "kueue-operator.v1.4.1",
+            "skips": [
+                "kueue-operator.v1.4.0"
+            ]
         }
     ]
 }
@@ -675,6 +680,132 @@
         {
             "name": "operand-image",
             "image": "registry.redhat.io/kueue/kueue-rhel9@sha256:35df4246eddb9444f30e595ff6f40ed8b1f040df7a13c547074100120398808c"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "kueue-operator.v1.4.1",
+    "package": "kueue-operator",
+    "image": "registry.redhat.io/kueue/kueue-operator-bundle@sha256:2a2217f0277a39ccccaafc742c06d7b834ae1dd834d749c4b8ad0a4b5e2b01ce",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "kueue.openshift.io",
+                "kind": "Kueue",
+                "version": "v1"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "kueue-operator",
+                "version": "1.4.1"
+            }
+        },
+        {
+            "type": "olm.csv.metadata",
+            "value": {
+                "annotations": {
+                    "alm-examples": "[\n  {\n    \"apiVersion\": \"kueue.openshift.io/v1\",\n    \"kind\": \"Kueue\",\n    \"metadata\": {\n      \"labels\": {\n        \"app.kubernetes.io/managed-by\": \"kustomize\",\n        \"app.kubernetes.io/name\": \"kueue-operator\"\n      },\n      \"name\": \"cluster\"\n    },\n    \"spec\": {\n      \"config\": {\n        \"integrations\": {\n          \"frameworks\": [\n            \"BatchJob\"\n          ]\n        }\n      },\n      \"managementState\": \"Managed\"\n    }\n  }\n]",
+                    "capabilities": "Basic Install",
+                    "console.openshift.io/operator-monitoring-default": "true",
+                    "createdAt": "2026-08-03T20:53:18Z",
+                    "features.operators.openshift.io/cnf": "false",
+                    "features.operators.openshift.io/cni": "false",
+                    "features.operators.openshift.io/csi": "false",
+                    "features.operators.openshift.io/disconnected": "true",
+                    "features.operators.openshift.io/fips-compliant": "true",
+                    "features.operators.openshift.io/proxy-aware": "false",
+                    "features.operators.openshift.io/tls-profiles": "true",
+                    "features.operators.openshift.io/token-auth-aws": "false",
+                    "features.operators.openshift.io/token-auth-azure": "false",
+                    "features.operators.openshift.io/token-auth-gcp": "false",
+                    "operatorframework.io/cluster-monitoring": "true",
+                    "operatorframework.io/suggested-namespace": "openshift-kueue-operator",
+                    "operators.openshift.io/valid-subscription": "[\"OpenShift Kubernetes Engine\", \"OpenShift Container Platform\", \"OpenShift Platform Plus\"]",
+                    "operators.operatorframework.io/builder": "operator-sdk-v1.37.0",
+                    "operators.operatorframework.io/project_layout": "go.kubebuilder.io/v4"
+                },
+                "apiServiceDefinitions": {},
+                "crdDescriptions": {
+                    "owned": [
+                        {
+                            "name": "kueues.kueue.openshift.io",
+                            "version": "v1",
+                            "kind": "Kueue",
+                            "displayName": "Kueue",
+                            "description": "Kueue is a cluster resource for configuration of the Kueue operand"
+                        }
+                    ]
+                },
+                "description": "Red Hat build of Kueue is a collection of APIs, based on the [Kueue](https://kueue.sigs.k8s.io/docs/) open source project, that extends Kubernetes to manage access to resources for jobs. Red Hat build of Kueue does not replace any existing components in a Kubernetes cluster, but instead integrates with the existing Kubernetes API server, scheduler, and cluster autoscaler components to determine when a job waits, is admitted to start by creating pods, or should be preempted.",
+                "displayName": "Red Hat build of Kueue",
+                "installModes": [
+                    {
+                        "type": "OwnNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "SingleNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "MultiNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "AllNamespaces",
+                        "supported": true
+                    }
+                ],
+                "keywords": [
+                    "kueue-operator"
+                ],
+                "labels": {
+                    "operatorframework.io/arch.amd64": "supported",
+                    "operatorframework.io/arch.arm64": "supported",
+                    "operatorframework.io/arch.ppc64le": "supported",
+                    "operatorframework.io/arch.s390x": "supported"
+                },
+                "links": [
+                    {
+                        "name": "Kueue Operator",
+                        "url": "https://github.com/openshift/kueue-operator"
+                    }
+                ],
+                "maintainers": [
+                    {
+                        "name": "Node team",
+                        "email": "aos-node@redhat.com"
+                    }
+                ],
+                "maturity": "stable",
+                "minKubeVersion": "1.28.0",
+                "provider": {
+                    "name": "Red Hat, Inc",
+                    "url": "https://github.com/openshift/kueue-operator"
+                }
+            }
+        }
+    ],
+    "relatedImages": [
+        {
+            "name": "must-gather",
+            "image": "registry.redhat.io/kueue/kueue-must-gather-rhel9@sha256:3ab73f249743cc48bc8e99dd776490c7bbb28f00b206f667ad0cd2558bce427b"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/kueue/kueue-operator-bundle@sha256:2a2217f0277a39ccccaafc742c06d7b834ae1dd834d749c4b8ad0a4b5e2b01ce"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/kueue/kueue-rhel9-operator@sha256:0cf6d39f8bf09c496123753b223ec5ff0b6234cd7b24b425b78d3cbf36e1aae9"
+        },
+        {
+            "name": "operand-image",
+            "image": "registry.redhat.io/kueue/kueue-rhel9@sha256:cdc406dab199d85bfb280b0f70bdd8a3865a46436bcd6ad72801343a281cabf4"
         }
     ]
 }

--- a/v4.21/catalog-template.yaml
+++ b/v4.21/catalog-template.yaml
@@ -8,3 +8,4 @@ Stable:
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:c26330443adc06876f5cc55952f78c7247a16bf577cc39d3e55eb3b695412361
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:c3e536c99c8ccb6777561d53a5af07bf604e9ddbf945fa430e91c0c10dd3aaf0
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:eff8cc23c2f37ba4c1a27a622aa87ae0ad3190b95b5c78b064f0605249c6189a
+  - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:2a2217f0277a39ccccaafc742c06d7b834ae1dd834d749c4b8ad0a4b5e2b01ce

--- a/v4.21/catalog/kueue-operator/catalog.json
+++ b/v4.21/catalog/kueue-operator/catalog.json
@@ -29,7 +29,6 @@
         }
     ]
 }
-
 {
     "schema": "olm.channel",
     "name": "stable-v1.4",
@@ -37,6 +36,12 @@
     "entries": [
         {
             "name": "kueue-operator.v1.4.0"
+        },
+        {
+            "name": "kueue-operator.v1.4.1",
+            "skips": [
+                "kueue-operator.v1.4.0"
+            ]
         }
     ]
 }
@@ -541,6 +546,132 @@
         {
             "name": "operand-image",
             "image": "registry.redhat.io/kueue/kueue-rhel9@sha256:35df4246eddb9444f30e595ff6f40ed8b1f040df7a13c547074100120398808c"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "kueue-operator.v1.4.1",
+    "package": "kueue-operator",
+    "image": "registry.redhat.io/kueue/kueue-operator-bundle@sha256:2a2217f0277a39ccccaafc742c06d7b834ae1dd834d749c4b8ad0a4b5e2b01ce",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "kueue.openshift.io",
+                "kind": "Kueue",
+                "version": "v1"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "kueue-operator",
+                "version": "1.4.1"
+            }
+        },
+        {
+            "type": "olm.csv.metadata",
+            "value": {
+                "annotations": {
+                    "alm-examples": "[\n  {\n    \"apiVersion\": \"kueue.openshift.io/v1\",\n    \"kind\": \"Kueue\",\n    \"metadata\": {\n      \"labels\": {\n        \"app.kubernetes.io/managed-by\": \"kustomize\",\n        \"app.kubernetes.io/name\": \"kueue-operator\"\n      },\n      \"name\": \"cluster\"\n    },\n    \"spec\": {\n      \"config\": {\n        \"integrations\": {\n          \"frameworks\": [\n            \"BatchJob\"\n          ]\n        }\n      },\n      \"managementState\": \"Managed\"\n    }\n  }\n]",
+                    "capabilities": "Basic Install",
+                    "console.openshift.io/operator-monitoring-default": "true",
+                    "createdAt": "2026-08-03T20:53:18Z",
+                    "features.operators.openshift.io/cnf": "false",
+                    "features.operators.openshift.io/cni": "false",
+                    "features.operators.openshift.io/csi": "false",
+                    "features.operators.openshift.io/disconnected": "true",
+                    "features.operators.openshift.io/fips-compliant": "true",
+                    "features.operators.openshift.io/proxy-aware": "false",
+                    "features.operators.openshift.io/tls-profiles": "true",
+                    "features.operators.openshift.io/token-auth-aws": "false",
+                    "features.operators.openshift.io/token-auth-azure": "false",
+                    "features.operators.openshift.io/token-auth-gcp": "false",
+                    "operatorframework.io/cluster-monitoring": "true",
+                    "operatorframework.io/suggested-namespace": "openshift-kueue-operator",
+                    "operators.openshift.io/valid-subscription": "[\"OpenShift Kubernetes Engine\", \"OpenShift Container Platform\", \"OpenShift Platform Plus\"]",
+                    "operators.operatorframework.io/builder": "operator-sdk-v1.37.0",
+                    "operators.operatorframework.io/project_layout": "go.kubebuilder.io/v4"
+                },
+                "apiServiceDefinitions": {},
+                "crdDescriptions": {
+                    "owned": [
+                        {
+                            "name": "kueues.kueue.openshift.io",
+                            "version": "v1",
+                            "kind": "Kueue",
+                            "displayName": "Kueue",
+                            "description": "Kueue is a cluster resource for configuration of the Kueue operand"
+                        }
+                    ]
+                },
+                "description": "Red Hat build of Kueue is a collection of APIs, based on the [Kueue](https://kueue.sigs.k8s.io/docs/) open source project, that extends Kubernetes to manage access to resources for jobs. Red Hat build of Kueue does not replace any existing components in a Kubernetes cluster, but instead integrates with the existing Kubernetes API server, scheduler, and cluster autoscaler components to determine when a job waits, is admitted to start by creating pods, or should be preempted.",
+                "displayName": "Red Hat build of Kueue",
+                "installModes": [
+                    {
+                        "type": "OwnNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "SingleNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "MultiNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "AllNamespaces",
+                        "supported": true
+                    }
+                ],
+                "keywords": [
+                    "kueue-operator"
+                ],
+                "labels": {
+                    "operatorframework.io/arch.amd64": "supported",
+                    "operatorframework.io/arch.arm64": "supported",
+                    "operatorframework.io/arch.ppc64le": "supported",
+                    "operatorframework.io/arch.s390x": "supported"
+                },
+                "links": [
+                    {
+                        "name": "Kueue Operator",
+                        "url": "https://github.com/openshift/kueue-operator"
+                    }
+                ],
+                "maintainers": [
+                    {
+                        "name": "Node team",
+                        "email": "aos-node@redhat.com"
+                    }
+                ],
+                "maturity": "stable",
+                "minKubeVersion": "1.28.0",
+                "provider": {
+                    "name": "Red Hat, Inc",
+                    "url": "https://github.com/openshift/kueue-operator"
+                }
+            }
+        }
+    ],
+    "relatedImages": [
+        {
+            "name": "must-gather",
+            "image": "registry.redhat.io/kueue/kueue-must-gather-rhel9@sha256:3ab73f249743cc48bc8e99dd776490c7bbb28f00b206f667ad0cd2558bce427b"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/kueue/kueue-operator-bundle@sha256:2a2217f0277a39ccccaafc742c06d7b834ae1dd834d749c4b8ad0a4b5e2b01ce"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/kueue/kueue-rhel9-operator@sha256:0cf6d39f8bf09c496123753b223ec5ff0b6234cd7b24b425b78d3cbf36e1aae9"
+        },
+        {
+            "name": "operand-image",
+            "image": "registry.redhat.io/kueue/kueue-rhel9@sha256:cdc406dab199d85bfb280b0f70bdd8a3865a46436bcd6ad72801343a281cabf4"
         }
     ]
 }

--- a/v4.22/catalog-template.yaml
+++ b/v4.22/catalog-template.yaml
@@ -6,3 +6,4 @@ Stable:
   Bundles:
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:c3e536c99c8ccb6777561d53a5af07bf604e9ddbf945fa430e91c0c10dd3aaf0
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:eff8cc23c2f37ba4c1a27a622aa87ae0ad3190b95b5c78b064f0605249c6189a
+  - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:2a2217f0277a39ccccaafc742c06d7b834ae1dd834d749c4b8ad0a4b5e2b01ce

--- a/v4.22/catalog/kueue-operator/catalog.json
+++ b/v4.22/catalog/kueue-operator/catalog.json
@@ -13,7 +13,6 @@
         }
     ]
 }
-
 {
     "schema": "olm.channel",
     "name": "stable-v1.4",
@@ -21,6 +20,12 @@
     "entries": [
         {
             "name": "kueue-operator.v1.4.0"
+        },
+        {
+            "name": "kueue-operator.v1.4.1",
+            "skips": [
+                "kueue-operator.v1.4.0"
+            ]
         }
     ]
 }
@@ -273,6 +278,132 @@
         {
             "name": "operand-image",
             "image": "registry.redhat.io/kueue/kueue-rhel9@sha256:35df4246eddb9444f30e595ff6f40ed8b1f040df7a13c547074100120398808c"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "kueue-operator.v1.4.1",
+    "package": "kueue-operator",
+    "image": "registry.redhat.io/kueue/kueue-operator-bundle@sha256:2a2217f0277a39ccccaafc742c06d7b834ae1dd834d749c4b8ad0a4b5e2b01ce",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "kueue.openshift.io",
+                "kind": "Kueue",
+                "version": "v1"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "kueue-operator",
+                "version": "1.4.1"
+            }
+        },
+        {
+            "type": "olm.csv.metadata",
+            "value": {
+                "annotations": {
+                    "alm-examples": "[\n  {\n    \"apiVersion\": \"kueue.openshift.io/v1\",\n    \"kind\": \"Kueue\",\n    \"metadata\": {\n      \"labels\": {\n        \"app.kubernetes.io/managed-by\": \"kustomize\",\n        \"app.kubernetes.io/name\": \"kueue-operator\"\n      },\n      \"name\": \"cluster\"\n    },\n    \"spec\": {\n      \"config\": {\n        \"integrations\": {\n          \"frameworks\": [\n            \"BatchJob\"\n          ]\n        }\n      },\n      \"managementState\": \"Managed\"\n    }\n  }\n]",
+                    "capabilities": "Basic Install",
+                    "console.openshift.io/operator-monitoring-default": "true",
+                    "createdAt": "2026-08-03T20:53:18Z",
+                    "features.operators.openshift.io/cnf": "false",
+                    "features.operators.openshift.io/cni": "false",
+                    "features.operators.openshift.io/csi": "false",
+                    "features.operators.openshift.io/disconnected": "true",
+                    "features.operators.openshift.io/fips-compliant": "true",
+                    "features.operators.openshift.io/proxy-aware": "false",
+                    "features.operators.openshift.io/tls-profiles": "true",
+                    "features.operators.openshift.io/token-auth-aws": "false",
+                    "features.operators.openshift.io/token-auth-azure": "false",
+                    "features.operators.openshift.io/token-auth-gcp": "false",
+                    "operatorframework.io/cluster-monitoring": "true",
+                    "operatorframework.io/suggested-namespace": "openshift-kueue-operator",
+                    "operators.openshift.io/valid-subscription": "[\"OpenShift Kubernetes Engine\", \"OpenShift Container Platform\", \"OpenShift Platform Plus\"]",
+                    "operators.operatorframework.io/builder": "operator-sdk-v1.37.0",
+                    "operators.operatorframework.io/project_layout": "go.kubebuilder.io/v4"
+                },
+                "apiServiceDefinitions": {},
+                "crdDescriptions": {
+                    "owned": [
+                        {
+                            "name": "kueues.kueue.openshift.io",
+                            "version": "v1",
+                            "kind": "Kueue",
+                            "displayName": "Kueue",
+                            "description": "Kueue is a cluster resource for configuration of the Kueue operand"
+                        }
+                    ]
+                },
+                "description": "Red Hat build of Kueue is a collection of APIs, based on the [Kueue](https://kueue.sigs.k8s.io/docs/) open source project, that extends Kubernetes to manage access to resources for jobs. Red Hat build of Kueue does not replace any existing components in a Kubernetes cluster, but instead integrates with the existing Kubernetes API server, scheduler, and cluster autoscaler components to determine when a job waits, is admitted to start by creating pods, or should be preempted.",
+                "displayName": "Red Hat build of Kueue",
+                "installModes": [
+                    {
+                        "type": "OwnNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "SingleNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "MultiNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "AllNamespaces",
+                        "supported": true
+                    }
+                ],
+                "keywords": [
+                    "kueue-operator"
+                ],
+                "labels": {
+                    "operatorframework.io/arch.amd64": "supported",
+                    "operatorframework.io/arch.arm64": "supported",
+                    "operatorframework.io/arch.ppc64le": "supported",
+                    "operatorframework.io/arch.s390x": "supported"
+                },
+                "links": [
+                    {
+                        "name": "Kueue Operator",
+                        "url": "https://github.com/openshift/kueue-operator"
+                    }
+                ],
+                "maintainers": [
+                    {
+                        "name": "Node team",
+                        "email": "aos-node@redhat.com"
+                    }
+                ],
+                "maturity": "stable",
+                "minKubeVersion": "1.28.0",
+                "provider": {
+                    "name": "Red Hat, Inc",
+                    "url": "https://github.com/openshift/kueue-operator"
+                }
+            }
+        }
+    ],
+    "relatedImages": [
+        {
+            "name": "must-gather",
+            "image": "registry.redhat.io/kueue/kueue-must-gather-rhel9@sha256:3ab73f249743cc48bc8e99dd776490c7bbb28f00b206f667ad0cd2558bce427b"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/kueue/kueue-operator-bundle@sha256:2a2217f0277a39ccccaafc742c06d7b834ae1dd834d749c4b8ad0a4b5e2b01ce"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/kueue/kueue-rhel9-operator@sha256:0cf6d39f8bf09c496123753b223ec5ff0b6234cd7b24b425b78d3cbf36e1aae9"
+        },
+        {
+            "name": "operand-image",
+            "image": "registry.redhat.io/kueue/kueue-rhel9@sha256:cdc406dab199d85bfb280b0f70bdd8a3865a46436bcd6ad72801343a281cabf4"
         }
     ]
 }

--- a/v5.0/catalog-template.yaml
+++ b/v5.0/catalog-template.yaml
@@ -6,3 +6,4 @@ Stable:
   Bundles:
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:c3e536c99c8ccb6777561d53a5af07bf604e9ddbf945fa430e91c0c10dd3aaf0
   - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:eff8cc23c2f37ba4c1a27a622aa87ae0ad3190b95b5c78b064f0605249c6189a
+  - Image: registry.redhat.io/kueue/kueue-operator-bundle@sha256:2a2217f0277a39ccccaafc742c06d7b834ae1dd834d749c4b8ad0a4b5e2b01ce

--- a/v5.0/catalog/kueue-operator/catalog.json
+++ b/v5.0/catalog/kueue-operator/catalog.json
@@ -13,7 +13,6 @@
         }
     ]
 }
-
 {
     "schema": "olm.channel",
     "name": "stable-v1.4",
@@ -21,6 +20,12 @@
     "entries": [
         {
             "name": "kueue-operator.v1.4.0"
+        },
+        {
+            "name": "kueue-operator.v1.4.1",
+            "skips": [
+                "kueue-operator.v1.4.0"
+            ]
         }
     ]
 }
@@ -273,6 +278,132 @@
         {
             "name": "operand-image",
             "image": "registry.redhat.io/kueue/kueue-rhel9@sha256:35df4246eddb9444f30e595ff6f40ed8b1f040df7a13c547074100120398808c"
+        }
+    ]
+}
+{
+    "schema": "olm.bundle",
+    "name": "kueue-operator.v1.4.1",
+    "package": "kueue-operator",
+    "image": "registry.redhat.io/kueue/kueue-operator-bundle@sha256:2a2217f0277a39ccccaafc742c06d7b834ae1dd834d749c4b8ad0a4b5e2b01ce",
+    "properties": [
+        {
+            "type": "olm.gvk",
+            "value": {
+                "group": "kueue.openshift.io",
+                "kind": "Kueue",
+                "version": "v1"
+            }
+        },
+        {
+            "type": "olm.package",
+            "value": {
+                "packageName": "kueue-operator",
+                "version": "1.4.1"
+            }
+        },
+        {
+            "type": "olm.csv.metadata",
+            "value": {
+                "annotations": {
+                    "alm-examples": "[\n  {\n    \"apiVersion\": \"kueue.openshift.io/v1\",\n    \"kind\": \"Kueue\",\n    \"metadata\": {\n      \"labels\": {\n        \"app.kubernetes.io/managed-by\": \"kustomize\",\n        \"app.kubernetes.io/name\": \"kueue-operator\"\n      },\n      \"name\": \"cluster\"\n    },\n    \"spec\": {\n      \"config\": {\n        \"integrations\": {\n          \"frameworks\": [\n            \"BatchJob\"\n          ]\n        }\n      },\n      \"managementState\": \"Managed\"\n    }\n  }\n]",
+                    "capabilities": "Basic Install",
+                    "console.openshift.io/operator-monitoring-default": "true",
+                    "createdAt": "2026-08-03T20:53:18Z",
+                    "features.operators.openshift.io/cnf": "false",
+                    "features.operators.openshift.io/cni": "false",
+                    "features.operators.openshift.io/csi": "false",
+                    "features.operators.openshift.io/disconnected": "true",
+                    "features.operators.openshift.io/fips-compliant": "true",
+                    "features.operators.openshift.io/proxy-aware": "false",
+                    "features.operators.openshift.io/tls-profiles": "true",
+                    "features.operators.openshift.io/token-auth-aws": "false",
+                    "features.operators.openshift.io/token-auth-azure": "false",
+                    "features.operators.openshift.io/token-auth-gcp": "false",
+                    "operatorframework.io/cluster-monitoring": "true",
+                    "operatorframework.io/suggested-namespace": "openshift-kueue-operator",
+                    "operators.openshift.io/valid-subscription": "[\"OpenShift Kubernetes Engine\", \"OpenShift Container Platform\", \"OpenShift Platform Plus\"]",
+                    "operators.operatorframework.io/builder": "operator-sdk-v1.37.0",
+                    "operators.operatorframework.io/project_layout": "go.kubebuilder.io/v4"
+                },
+                "apiServiceDefinitions": {},
+                "crdDescriptions": {
+                    "owned": [
+                        {
+                            "name": "kueues.kueue.openshift.io",
+                            "version": "v1",
+                            "kind": "Kueue",
+                            "displayName": "Kueue",
+                            "description": "Kueue is a cluster resource for configuration of the Kueue operand"
+                        }
+                    ]
+                },
+                "description": "Red Hat build of Kueue is a collection of APIs, based on the [Kueue](https://kueue.sigs.k8s.io/docs/) open source project, that extends Kubernetes to manage access to resources for jobs. Red Hat build of Kueue does not replace any existing components in a Kubernetes cluster, but instead integrates with the existing Kubernetes API server, scheduler, and cluster autoscaler components to determine when a job waits, is admitted to start by creating pods, or should be preempted.",
+                "displayName": "Red Hat build of Kueue",
+                "installModes": [
+                    {
+                        "type": "OwnNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "SingleNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "MultiNamespace",
+                        "supported": false
+                    },
+                    {
+                        "type": "AllNamespaces",
+                        "supported": true
+                    }
+                ],
+                "keywords": [
+                    "kueue-operator"
+                ],
+                "labels": {
+                    "operatorframework.io/arch.amd64": "supported",
+                    "operatorframework.io/arch.arm64": "supported",
+                    "operatorframework.io/arch.ppc64le": "supported",
+                    "operatorframework.io/arch.s390x": "supported"
+                },
+                "links": [
+                    {
+                        "name": "Kueue Operator",
+                        "url": "https://github.com/openshift/kueue-operator"
+                    }
+                ],
+                "maintainers": [
+                    {
+                        "name": "Node team",
+                        "email": "aos-node@redhat.com"
+                    }
+                ],
+                "maturity": "stable",
+                "minKubeVersion": "1.28.0",
+                "provider": {
+                    "name": "Red Hat, Inc",
+                    "url": "https://github.com/openshift/kueue-operator"
+                }
+            }
+        }
+    ],
+    "relatedImages": [
+        {
+            "name": "must-gather",
+            "image": "registry.redhat.io/kueue/kueue-must-gather-rhel9@sha256:3ab73f249743cc48bc8e99dd776490c7bbb28f00b206f667ad0cd2558bce427b"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/kueue/kueue-operator-bundle@sha256:2a2217f0277a39ccccaafc742c06d7b834ae1dd834d749c4b8ad0a4b5e2b01ce"
+        },
+        {
+            "name": "",
+            "image": "registry.redhat.io/kueue/kueue-rhel9-operator@sha256:0cf6d39f8bf09c496123753b223ec5ff0b6234cd7b24b425b78d3cbf36e1aae9"
+        },
+        {
+            "name": "operand-image",
+            "image": "registry.redhat.io/kueue/kueue-rhel9@sha256:cdc406dab199d85bfb280b0f70bdd8a3865a46436bcd6ad72801343a281cabf4"
         }
     ]
 }


### PR DESCRIPTION
Release Kueue 1.4.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kueue Operator version 1.4.1 to the stable v1.4 channel across supported platform catalogs.
  * Updated upgrade paths to move directly from version 1.4.0 to 1.4.1.
  * Added the corresponding bundle metadata and verified image references for the operator and related components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->